### PR TITLE
optimize batch normalization and relu layer

### DIFF
--- a/include/caffe/layers/batch_norm_layer.hpp
+++ b/include/caffe/layers/batch_norm_layer.hpp
@@ -82,12 +82,6 @@ class BatchNormLayer : public Layer<Dtype> {
   Dtype moving_average_fraction_;
   int channels_;
   Dtype eps_;
-
-  // extra temporarary variables is used to carry out sums/broadcasting
-  // using BLAS
-  Blob<Dtype> batch_sum_multiplier_;
-  Blob<Dtype> num_by_chans_;
-  Blob<Dtype> spatial_sum_multiplier_;
 };
 
 }  // namespace caffe

--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -1,7 +1,9 @@
 #include <algorithm>
 #include <functional>
 #include <vector>
+#include <omp.h>
 
+#include "caffe/filler.hpp"
 #include "caffe/layers/batch_norm_layer.hpp"
 #include "caffe/util/math_functions.hpp"
 
@@ -23,14 +25,30 @@ void BatchNormLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
   if (this->blobs_.size() > 0) {
     LOG(INFO) << "Skipping parameter initialization";
   } else {
-    this->blobs_.resize(3);
+    this->blobs_.resize(5);
     vector<int> sz;
     sz.push_back(channels_);
     this->blobs_[0].reset(new Blob<Dtype>(sz));
     this->blobs_[1].reset(new Blob<Dtype>(sz));
-    sz[0]=1;
     this->blobs_[2].reset(new Blob<Dtype>(sz));
-    for (int i = 0; i < 3; ++i) {
+    this->blobs_[3].reset(new Blob<Dtype>(sz));
+    sz[0]=1;
+    this->blobs_[4].reset(new Blob<Dtype>(sz));
+    FillerParameter scale_filler_param(param.scale_filler());
+    FillerParameter shift_filler_param(param.shift_filler());
+    if (!param.has_scale_filler()) {
+        scale_filler_param.set_type("constant");
+        scale_filler_param.set_value(1);
+    }
+    if (!param.has_shift_filler()) {
+        shift_filler_param.set_type("constant");
+        shift_filler_param.set_value(0);
+    }
+    shared_ptr<Filler<Dtype> > scale_filler(GetFiller<Dtype>(scale_filler_param));
+    shared_ptr<Filler<Dtype> > shift_filler(GetFiller<Dtype>(shift_filler_param));
+    scale_filler->Fill(this->blobs_[0].get());
+    shift_filler->Fill(this->blobs_[1].get());
+    for (int i = 2; i < 5; ++i) {
       caffe_set(this->blobs_[i]->count(), Dtype(0),
                 this->blobs_[i]->mutable_cpu_data());
     }
@@ -43,76 +61,79 @@ void BatchNormLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
   if (bottom[0]->num_axes() >= 1)
     CHECK_EQ(bottom[0]->shape(1), channels_);
   top[0]->ReshapeLike(*bottom[0]);
-
-  vector<int> sz;
-  sz.push_back(channels_);
-  mean_.Reshape(sz);
-  variance_.Reshape(sz);
-  temp_.ReshapeLike(*bottom[0]);
+  mean_.Reshape(1, channels_, 1, 1);
+  variance_.Reshape(1, channels_, 1, 1);
   x_norm_.ReshapeLike(*bottom[0]);
-  sz[0]=bottom[0]->shape(0);
-  batch_sum_multiplier_.Reshape(sz);
-
-  int spatial_dim = bottom[0]->count()/(channels_*bottom[0]->shape(0));
-  if (spatial_sum_multiplier_.num_axes() == 0 ||
-      spatial_sum_multiplier_.shape(0) != spatial_dim) {
-    sz[0] = spatial_dim;
-    spatial_sum_multiplier_.Reshape(sz);
-    Dtype* multiplier_data = spatial_sum_multiplier_.mutable_cpu_data();
-    caffe_set(spatial_sum_multiplier_.count(), Dtype(1), multiplier_data);
-  }
-
-  int numbychans = channels_*bottom[0]->shape(0);
-  if (num_by_chans_.num_axes() == 0 ||
-      num_by_chans_.shape(0) != numbychans) {
-    sz[0] = numbychans;
-    num_by_chans_.Reshape(sz);
-    caffe_set(batch_sum_multiplier_.count(), Dtype(1),
-        batch_sum_multiplier_.mutable_cpu_data());
-  }
 }
 
 template <typename Dtype>
-void BatchNormLayer<Dtype>::replicate(Dtype* buffer_to_write,
-                                      int num_batches,
-                                      unsigned int batch_offset_incr,
-                                      unsigned int channel_offset_incr,
-                                      const Dtype* data_to_be_replicated) {
-#ifdef _OPENMP
-  #pragma omp parallel for collapse(2)
-#endif
-  for (unsigned int j = 0; j< channels_; ++j) {
-    for (unsigned int n = 0; n < num_batches; ++n) {
-      caffe_set(channel_offset_incr, data_to_be_replicated[j],
-        buffer_to_write + j * channel_offset_incr + n * batch_offset_incr);
+void batch_mean(Dtype* batch_data, int N, int C, int HW, Dtype* batch_mean) {
+    int CHW = C * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        batch_mean[i] = 0;
+        Dtype* data = batch_data + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+                batch_mean[i] += data[k];
+            }
+            data += CHW;
+        }
     }
-  }
+
+    int NHW = N * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        //LOG(INFO) << "thread id: " << omp_get_thread_num();
+        batch_mean[i] /= NHW;
+    }
 }
 
 template <typename Dtype>
-template <typename FuncTy>
-void BatchNormLayer<Dtype>::replicate_to_op(Dtype* buffer_to_write,
-                                      int num_batches,
-                                      unsigned int batch_offset_incr,
-                                      unsigned int channel_offset_incr,
-                                      const Dtype* data_to_be_replicated,
-                                      FuncTy op_func) {
-#ifdef _OPENMP
-  #pragma omp parallel for collapse(2)
-#endif
-  for (unsigned int j = 0; j< channels_; ++j) {
-    for (unsigned int n = 0; n < num_batches; ++n) {
-      Dtype value = data_to_be_replicated[j];
-      Dtype* buffer_offsetted =
-        buffer_to_write + j * channel_offset_incr + n * batch_offset_incr;
-      for (unsigned int k = 0; k < channel_offset_incr; ++k) {
-        buffer_offsetted[k] = op_func(buffer_offsetted[k], value);
-      }
+void batch_variance(Dtype* batch_data, int N, int C, int HW, const Dtype* batch_mean, Dtype* batch_variance) {
+    int CHW = C * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        batch_variance[i] = 0;
+        Dtype* data = batch_data + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+                batch_variance[i] += data[k];
+            }
+            data += CHW;
+        }
     }
-  }
+
+    int NHW = N * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        batch_variance[i] /= NHW;
+        batch_variance[i] -= batch_mean[i] * batch_mean[i];
+    }
 }
 
-
+template<typename Dtype>
+void batch_norm(Dtype* bottom_data, const Dtype* batch_mean, const Dtype* batch_variance, \
+        const Dtype* scale, const Dtype* shift, Dtype eps, int N, int C, int HW, \
+        Dtype* x_norm, Dtype* top_data) {
+    int CHW = C * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        Dtype factor = 1.0 / sqrt(eps + batch_variance[i]);
+        Dtype* bottom = bottom_data + i * HW;
+        Dtype* top = top_data + i * HW;
+        Dtype* norm = x_norm + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+                norm[k] = (bottom[k] - batch_mean[i]) * factor;
+                top[k] = scale[i] * norm[k] + shift[i];
+            }
+            bottom += CHW;
+            top += CHW;
+            norm += CHW;
+        }
+    }
+}
 
 template <typename Dtype>
 void BatchNormLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
@@ -120,155 +141,129 @@ void BatchNormLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   const Dtype* bottom_data = bottom[0]->cpu_data();
   Dtype* top_data = top[0]->mutable_cpu_data();
   int num = bottom[0]->shape(0);
-  int spatial_dim = bottom[0]->count()/(bottom[0]->shape(0)*channels_);
+  int spatial_dim = bottom[0]->count() / (num * channels_);
 
-  if (bottom[0] != top[0]) {
-    caffe_copy(bottom[0]->count(), bottom_data, top_data);
-  }
-
+  const Dtype* scale_data = this->blobs_[0]->cpu_data();
+  const Dtype* shift_data = this->blobs_[1]->cpu_data();
   if (use_global_stats_) {
     // use the stored mean/variance estimates.
-    const Dtype scale_factor = this->blobs_[2]->cpu_data()[0] == 0 ?
-        0 : 1 / this->blobs_[2]->cpu_data()[0];
-    caffe_cpu_scale(variance_.count(), scale_factor,
-        this->blobs_[0]->cpu_data(), mean_.mutable_cpu_data());
-    caffe_cpu_scale(variance_.count(), scale_factor,
-        this->blobs_[1]->cpu_data(), variance_.mutable_cpu_data());
+    const Dtype factor = this->blobs_[4]->cpu_data()[0] == 0 ?
+        0 : 1 / this->blobs_[4]->cpu_data()[0];
+    caffe_cpu_scale(variance_.count(), factor,
+        this->blobs_[2]->cpu_data(), mean_.mutable_cpu_data());
+    caffe_cpu_scale(variance_.count(), factor,
+        this->blobs_[3]->cpu_data(), variance_.mutable_cpu_data());
   } else {
     // compute mean
-    caffe_cpu_gemv<Dtype>(CblasNoTrans, channels_ * num, spatial_dim,
-        1. / (num * spatial_dim), bottom_data,
-        spatial_sum_multiplier_.cpu_data(), 0.,
-        num_by_chans_.mutable_cpu_data());
-    caffe_cpu_gemv<Dtype>(CblasTrans, num, channels_, 1.,
-        num_by_chans_.cpu_data(), batch_sum_multiplier_.cpu_data(), 0.,
-        mean_.mutable_cpu_data());
+      batch_mean(bottom[0]->mutable_cpu_data(), num, channels_, spatial_dim, \
+              mean_.mutable_cpu_data());
   }
 
   // subtract mean
-  replicate_to_op(top_data,
-                  num,
-                  spatial_dim*channels_,
-                  spatial_dim,
-                  mean_.cpu_data(),
-                  std::minus<Dtype>());
-
   if (!use_global_stats_) {
     // compute variance using var(X) = E((X-EX)^2)
-    caffe_powx(top[0]->count(), top_data, Dtype(2),
-        temp_.mutable_cpu_data());  // (X-EX)^2
-    caffe_cpu_gemv<Dtype>(CblasNoTrans, channels_ * num, spatial_dim,
-        1. / (num * spatial_dim), temp_.cpu_data(),
-        spatial_sum_multiplier_.cpu_data(), 0.,
-        num_by_chans_.mutable_cpu_data());
-    caffe_cpu_gemv<Dtype>(CblasTrans, num, channels_, 1.,
-        num_by_chans_.cpu_data(), batch_sum_multiplier_.cpu_data(), 0.,
-        variance_.mutable_cpu_data());  // E((X_EX)^2)
+    caffe_powx(bottom[0]->count(), bottom_data, Dtype(2),
+        x_norm_.mutable_cpu_data());  // (X-EX)^2
 
+    batch_variance(x_norm_.mutable_cpu_data(), num, channels_, spatial_dim, \
+            mean_.cpu_data(), variance_.mutable_cpu_data());
     // compute and save moving average
-    this->blobs_[2]->mutable_cpu_data()[0] *= moving_average_fraction_;
-    this->blobs_[2]->mutable_cpu_data()[0] += 1;
+    this->blobs_[4]->mutable_cpu_data()[0] *= moving_average_fraction_;
+    this->blobs_[4]->mutable_cpu_data()[0] += 1;
+
     caffe_cpu_axpby(mean_.count(), Dtype(1), mean_.cpu_data(),
-        moving_average_fraction_, this->blobs_[0]->mutable_cpu_data());
+        moving_average_fraction_, this->blobs_[2]->mutable_cpu_data());
     int m = bottom[0]->count()/channels_;
     Dtype bias_correction_factor = m > 1 ? Dtype(m)/(m-1) : 1;
     caffe_cpu_axpby(variance_.count(), bias_correction_factor,
         variance_.cpu_data(), moving_average_fraction_,
-        this->blobs_[1]->mutable_cpu_data());
+        this->blobs_[3]->mutable_cpu_data());
   }
 
   // normalize variance
-  caffe_add_scalar(variance_.count(), eps_, variance_.mutable_cpu_data());
-  caffe_powx(variance_.count(), variance_.cpu_data(), Dtype(0.5),
-             variance_.mutable_cpu_data());
+  batch_norm(bottom[0]->mutable_cpu_data(), mean_.cpu_data(), variance_.cpu_data(), \
+         scale_data, shift_data, eps_, num, channels_, spatial_dim, x_norm_.mutable_cpu_data(), \
+         top_data);
+}
 
-  // replicate variance to input size
-  this->replicate(temp_.mutable_cpu_data(),
-                  num,
-                  spatial_dim*channels_,
-                  spatial_dim,
-                  variance_.cpu_data());
+template<typename Dtype>
+void batch_diff(Dtype* top_diff, Dtype* x_norm, int N, int C, int HW, Dtype* scale_diff, \
+       Dtype* shift_diff) {
+    int CHW = C * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        scale_diff[i] = 0;
+   //     shift_diff[i] = 0;
+        Dtype* top = top_diff + i * HW;
+        Dtype* norm = x_norm + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+                scale_diff[i] += top[k] * norm[k];
+   //             shift_diff[i] += top[k];
+            }
+            top += CHW;
+            norm += CHW;
+        }
+    }
 
-  caffe_div(temp_.count(), top_data, temp_.cpu_data(), top_data);
-  // TODO(cdoersch): The caching is only needed because later in-place layers
-  //                 might clobber the data.  Can we skip this if they won't?
-  caffe_copy(x_norm_.count(), top_data,
-      x_norm_.mutable_cpu_data());
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+   //     scale_diff[i] = 0;
+        shift_diff[i] = 0;
+        Dtype* top = top_diff + i * HW;
+        Dtype* norm = x_norm + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+   //             scale_diff[i] += top[k] * norm[k];
+                shift_diff[i] += top[k];
+            }
+            top += CHW;
+            norm += CHW;
+        }
+    }
+}
+
+template<typename Dtype>
+void batch_x_diff(Dtype* top_diff, Dtype* x_norm, const Dtype* variance, \
+        const Dtype* scale_diff, const Dtype* shift_diff, const Dtype* scale, \
+        Dtype eps, int N, int C, int HW, Dtype* bottom_diff) {
+    int CHW = C * HW;
+    int m = N * HW;
+    #pragma omp parallel for
+    for (int i = 0; i < C; ++i) {
+        Dtype factor = scale[i] / sqrt(variance[i] + eps);
+        Dtype* top = top_diff + i * HW;
+        Dtype* norm = x_norm + i * HW;
+        Dtype* bottom = bottom_diff + i * HW;
+        for (int j = 0; j < N; ++j) {
+            for (int k = 0; k < HW; ++k) {
+                bottom[k] = factor * (top[k] - (shift_diff[i] + norm[k] * scale_diff[i]) / m);
+            }
+            top += CHW;
+            norm += CHW;
+            bottom += CHW;
+        }
+    }
 }
 
 template <typename Dtype>
 void BatchNormLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     const vector<bool>& propagate_down,
     const vector<Blob<Dtype>*>& bottom) {
-  const Dtype* top_diff;
-  if (bottom[0] != top[0]) {
-    top_diff = top[0]->cpu_diff();
-  } else {
-    caffe_copy(x_norm_.count(), top[0]->cpu_diff(), x_norm_.mutable_cpu_diff());
-    top_diff = x_norm_.cpu_diff();
-  }
+  Dtype* top_diff = top[0]->mutable_cpu_diff();
   Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
-  if (use_global_stats_) {
-    caffe_div(temp_.count(), top_diff, temp_.cpu_data(), bottom_diff);
-    return;
-  }
-  const Dtype* top_data = x_norm_.cpu_data();
+
+  Dtype* norm_data = x_norm_.mutable_cpu_data();
   int num = bottom[0]->shape()[0];
-  int spatial_dim = bottom[0]->count()/(bottom[0]->shape(0)*channels_);
-  // if Y = (X-mean(X))/(sqrt(var(X)+eps)), then
-  //
-  // dE(Y)/dX =
-  //   (dE/dY - mean(dE/dY) - mean(dE/dY \cdot Y) \cdot Y)
-  //     ./ sqrt(var(X) + eps)
-  //
-  // where \cdot and ./ are hadamard product and elementwise division,
-  // respectively, dE/dY is the top diff, and mean/var/sum are all computed
-  // along all dimensions except the channels dimension.  In the above
-  // equation, the operations allow for expansion (i.e. broadcast) along all
-  // dimensions except the channels dimension where required.
+  int spatial_dim = bottom[0]->count() / (num * channels_);
+  const Dtype* scale_data = this->blobs_[0]->cpu_data();
+  Dtype* scale_diff = this->blobs_[0]->mutable_cpu_diff();
+  Dtype* shift_diff = this->blobs_[1]->mutable_cpu_diff();
 
-  // sum(dE/dY \cdot Y)
-  caffe_mul(temp_.count(), top_data, top_diff, bottom_diff);
-  caffe_cpu_gemv<Dtype>(CblasNoTrans, channels_ * num, spatial_dim, 1.,
-      bottom_diff, spatial_sum_multiplier_.cpu_data(), 0.,
-      num_by_chans_.mutable_cpu_data());
-  caffe_cpu_gemv<Dtype>(CblasTrans, num, channels_, 1.,
-      num_by_chans_.cpu_data(), batch_sum_multiplier_.cpu_data(), 0.,
-      mean_.mutable_cpu_data());
+  batch_diff(top_diff, norm_data, num, channels_, spatial_dim, scale_diff, shift_diff);
 
-  this->replicate(bottom_diff,
-                  num,
-                  spatial_dim*channels_,
-                  spatial_dim,
-                  mean_.cpu_data());
-
-  // sum(dE/dY \cdot Y) \cdot Y
-  caffe_mul(temp_.count(), top_data, bottom_diff, bottom_diff);
-
-  // sum(dE/dY)-sum(dE/dY \cdot Y) \cdot Y
-  caffe_cpu_gemv<Dtype>(CblasNoTrans, channels_ * num, spatial_dim, 1.,
-      top_diff, spatial_sum_multiplier_.cpu_data(), 0.,
-      num_by_chans_.mutable_cpu_data());
-  caffe_cpu_gemv<Dtype>(CblasTrans, num, channels_, 1.,
-      num_by_chans_.cpu_data(), batch_sum_multiplier_.cpu_data(), 0.,
-      mean_.mutable_cpu_data());
-  // reshape (broadcast) the above to make
-  // sum(dE/dY)-sum(dE/dY \cdot Y) \cdot Y
-
-  replicate_to_op(bottom_diff,
-                  num,
-                  spatial_dim*channels_,
-                  spatial_dim,
-                  mean_.cpu_data(),
-                  std::plus<Dtype>());
-
-  // dE/dY - mean(dE/dY)-mean(dE/dY \cdot Y) \cdot Y
-  caffe_cpu_axpby(temp_.count(), Dtype(1), top_diff,
-      Dtype(-1. / (num * spatial_dim)), bottom_diff);
-
-  // note: temp_ still contains sqrt(var(X)+eps), computed during the forward
-  // pass.
-  caffe_div(temp_.count(), bottom_diff, temp_.cpu_data(), bottom_diff);
+  batch_x_diff(top_diff, norm_data, variance_.cpu_data(), scale_diff, \
+        shift_diff, scale_data, eps_, num, channels_, spatial_dim, bottom_diff);
 }
 
 

--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -12,21 +12,12 @@ void ReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* top_data = top[0]->mutable_cpu_data();
   const int count = bottom[0]->count();
   Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-
-  if (bottom[0] != top[0]) {
-      caffe_copy(count, bottom_data, top_data);
-  }
-  if (negative_slope == 0) {
-      #pragma omp parallel for
-      for (int i = 0; i < count; ++i) {
-          top_data[i] *= (bottom_data[i] > 0);
-      }
-  }
-  else {
-      #pragma omp parallel for
-      for (int i = 0; i < count; ++i) {
-          top_data[i] *= ((bottom_data[i] >= 0) + (bottom_data[i] < 0) * negative_slope);
-      }
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+  for (int i = 0; i < count; ++i) {
+    top_data[i] = std::max(bottom_data[i], Dtype(0))
+        + negative_slope * std::min(bottom_data[i], Dtype(0));
   }
 }
 
@@ -40,24 +31,12 @@ void ReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     const int count = bottom[0]->count();
     Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-    if (bottom[0] != top[0]) {
-        caffe_copy(count, top_diff, bottom_diff);
-    }
-    if (negative_slope == 0) {
-        #pragma omp parallel for
-        for (int i = 0; i < count; ++i) {
-            if (bottom_data[i] < 0) {
-                bottom_diff[i] = 0;
-            }
-        }
-    }
-    else {
-        #pragma omp parallel for
-        for (int i = 0; i < count; ++i) {
-            if (bottom_data[i] < 0) {
-                bottom_diff[i] *= negative_slope;
-            }
-        }
+#ifdef _OPENMP
+#pragma omp parallel for
+#endif
+    for (int i = 0; i < count; ++i) {
+      bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
+          + negative_slope * (bottom_data[i] <= 0));
     }
   }
 }

--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -12,12 +12,32 @@ void ReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
   Dtype* top_data = top[0]->mutable_cpu_data();
   const int count = bottom[0]->count();
   Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
-  for (int i = 0; i < count; ++i) {
-    top_data[i] = std::max(bottom_data[i], Dtype(0))
-        + negative_slope * std::min(bottom_data[i], Dtype(0));
+
+  if (bottom[0] != top[0]) {
+      caffe_copy(count, bottom_data, top_data);
+  }
+  if (negative_slope == 0) {
+      #pragma omp parallel for
+      for (int i = 0; i < count; ++i) {
+          top_data[i] *= (bottom_data[i] > 0);
+      }
+     /* int C = bottom[0]->shape(1);
+      int NHW = count / C;
+
+      #pragma omp parallel for
+      for (int i = 0; i < C; ++i) {
+          Dtype* top_data_tmp = top_data + i * NHW;
+          const Dtype* bot_data_tmp = bottom_data + i * NHW;
+          for (int j = 0; j < NHW; ++j) {
+              top_data_tmp[i] *= (bot_data_tmp[i] > 0);
+          }
+      }*/
+  }
+  else {
+      #pragma omp parallel for
+      for (int i = 0; i < count; ++i) {
+          top_data[i] *= ((bottom_data[i] >= 0) + (bottom_data[i] < 0) * negative_slope);
+      }
   }
 }
 
@@ -31,12 +51,33 @@ void ReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     const int count = bottom[0]->count();
     Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
+/*
 #ifdef _OPENMP
 #pragma omp parallel for
 #endif
     for (int i = 0; i < count; ++i) {
       bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
           + negative_slope * (bottom_data[i] <= 0));
+    }
+*/
+    if (bottom[0] != top[0]) {
+        caffe_copy(count, top_diff, bottom_diff);
+    }
+    if (negative_slope == 0) {
+        #pragma omp parallel for
+        for (int i = 0; i < count; ++i) {
+            if (bottom_data[i] < 0) {
+                bottom_diff[i] = 0;
+            }
+        }
+    }
+    else {
+        #pragma omp parallel for
+        for (int i = 0; i < count; ++i) {
+            if (bottom_data[i] < 0) {
+                bottom_diff[i] *= negative_slope;
+            }
+        }
     }
   }
 }

--- a/src/caffe/layers/relu_layer.cpp
+++ b/src/caffe/layers/relu_layer.cpp
@@ -21,17 +21,6 @@ void ReLULayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
       for (int i = 0; i < count; ++i) {
           top_data[i] *= (bottom_data[i] > 0);
       }
-     /* int C = bottom[0]->shape(1);
-      int NHW = count / C;
-
-      #pragma omp parallel for
-      for (int i = 0; i < C; ++i) {
-          Dtype* top_data_tmp = top_data + i * NHW;
-          const Dtype* bot_data_tmp = bottom_data + i * NHW;
-          for (int j = 0; j < NHW; ++j) {
-              top_data_tmp[i] *= (bot_data_tmp[i] > 0);
-          }
-      }*/
   }
   else {
       #pragma omp parallel for
@@ -51,15 +40,6 @@ void ReLULayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
     Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
     const int count = bottom[0]->count();
     Dtype negative_slope = this->layer_param_.relu_param().negative_slope();
-/*
-#ifdef _OPENMP
-#pragma omp parallel for
-#endif
-    for (int i = 0; i < count; ++i) {
-      bottom_diff[i] = top_diff[i] * ((bottom_data[i] > 0)
-          + negative_slope * (bottom_data[i] <= 0));
-    }
-*/
     if (bottom[0] != top[0]) {
         caffe_copy(count, top_diff, bottom_diff);
     }

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -580,8 +580,8 @@ message BatchNormParameter {
   optional Engine engine = 4 [default = DEFAULT];
   optional bool use_weight_bias = 5 [default = true];
   optional bool bias_term = 6 [default = true]; // whether to have bias terms
-  optional FillerParameter filler = 7; // The filler for the weight
-  optional FillerParameter bias_filler = 8; // The filler for the bias
+  optional FillerParameter scale_filler = 7; // The filler for the weight
+  optional FillerParameter shift_filler = 8; // The filler for the bias
 }
 
 message SplitParameter {


### PR DESCRIPTION
Merged the BatchNorm and Scale layer.
Optimize most elapsed time of batch normalization by re-writing the forward and backward process using OpenMP rather than BLAS to avoid additional multiply operation.
The elapsed time of ResNet-50 with batch size set by 128 fells from 32523.77ms to 16982.93ms on Intel(R) Xeon(R) CPU E5-2450 0 @ 2.10GHz.