### PR TITLE
Merged SSD implementation from https://github.com/weiliu89/caffe/tree…

### DIFF
--- a/LICENSE2
+++ b/LICENSE2
@@ -1,0 +1,48 @@
+Copyright (c) 2016 Wei Liu
+
+********************************************************************************
+COPYRIGHT
+
+All contributions by the University of California:
+Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
+All rights reserved.
+
+All other contributions:
+Copyright (c) 2014, 2015, the respective contributors
+All rights reserved.
+
+Caffe uses a shared copyright model: each contributor holds copyright over
+their contributions to Caffe. The project versioning records all such
+contribution and copyright details. If a contributor wants to further mark
+their specific copyright on a particular contribution, they should indicate
+their copyright solely in the commit message of the change when it is
+committed.
+
+LICENSE
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met: 
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer. 
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution. 
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+CONTRIBUTION AGREEMENT
+
+By contributing to the BVLC/caffe repository through pull-request, comment,
+or otherwise, the contributor releases their content to the
+license and copyright terms herein.
+********************************************************************************

--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,7 @@ ifneq ($(CPU_ONLY), 1)
 	LIBRARIES := cudart cublas curand
 endif
 
-LIBRARIES += glog gflags protobuf boost_system boost_filesystem m hdf5_hl hdf5
+LIBRARIES += glog gflags protobuf boost_system boost_filesystem boost_regex m hdf5_hl hdf5
 
 # handle IO dependencies
 USE_LEVELDB ?= 1

--- a/examples/ssd/deploy.prototxt
+++ b/examples/ssd/deploy.prototxt
@@ -1,0 +1,1604 @@
+name: "VGG_VOC0712_SSD_300x300_deploy"
+input: "data"
+input_shape {
+  dim: 1
+  dim: 3
+  dim: 300
+  dim: 300
+}
+layer {
+  name: "conv1_1"
+  type: "Convolution"
+  bottom: "data"
+  top: "conv1_1"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu1_1"
+  type: "ReLU"
+  bottom: "conv1_1"
+  top: "conv1_1"
+}
+layer {
+  name: "conv1_2"
+  type: "Convolution"
+  bottom: "conv1_1"
+  top: "conv1_2"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 64
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu1_2"
+  type: "ReLU"
+  bottom: "conv1_2"
+  top: "conv1_2"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "pool1"
+  type: "Pooling"
+  bottom: "conv1_2"
+  top: "pool1"
+  pooling_param {
+    engine: MKL2017
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv2_1"
+  type: "Convolution"
+  bottom: "pool1"
+  top: "conv2_1"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_1"
+  type: "ReLU"
+  bottom: "conv2_1"
+  top: "conv2_1"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv2_2"
+  type: "Convolution"
+  bottom: "conv2_1"
+  top: "conv2_2"
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  param {
+    lr_mult: 0
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 128
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu2_2"
+  type: "ReLU"
+  bottom: "conv2_2"
+  top: "conv2_2"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "pool2"
+  type: "Pooling"
+  bottom: "conv2_2"
+  top: "pool2"
+  pooling_param {
+    engine: MKL2017
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv3_1"
+  type: "Convolution"
+  bottom: "pool2"
+  top: "conv3_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_1"
+  type: "ReLU"
+  bottom: "conv3_1"
+  top: "conv3_1"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv3_2"
+  type: "Convolution"
+  bottom: "conv3_1"
+  top: "conv3_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_2"
+  type: "ReLU"
+  bottom: "conv3_2"
+  top: "conv3_2"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv3_3"
+  type: "Convolution"
+  bottom: "conv3_2"
+  top: "conv3_3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu3_3"
+  type: "ReLU"
+  bottom: "conv3_3"
+  top: "conv3_3"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "pool3"
+  type: "Pooling"
+  bottom: "conv3_3"
+  top: "pool3"
+  pooling_param {
+    engine: MKL2017
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv4_1"
+  type: "Convolution"
+  bottom: "pool3"
+  top: "conv4_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_1"
+  type: "ReLU"
+  bottom: "conv4_1"
+  top: "conv4_1"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv4_2"
+  type: "Convolution"
+  bottom: "conv4_1"
+  top: "conv4_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_2"
+  type: "ReLU"
+  bottom: "conv4_2"
+  top: "conv4_2"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv4_3"
+  type: "Convolution"
+  bottom: "conv4_2"
+  top: "conv4_3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu4_3"
+  type: "ReLU"
+  bottom: "conv4_3"
+  top: "conv4_3"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "pool4"
+  type: "Pooling"
+  bottom: "conv4_3"
+  top: "pool4"
+  pooling_param {
+    engine: MKL2017
+    pool: MAX
+    kernel_size: 2
+    stride: 2
+  }
+}
+layer {
+  name: "conv5_1"
+  type: "Convolution"
+  bottom: "pool4"
+  top: "conv5_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_1"
+  type: "ReLU"
+  bottom: "conv5_1"
+  top: "conv5_1"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv5_2"
+  type: "Convolution"
+  bottom: "conv5_1"
+  top: "conv5_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_2"
+  type: "ReLU"
+  bottom: "conv5_2"
+  top: "conv5_2"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "conv5_3"
+  type: "Convolution"
+  bottom: "conv5_2"
+  top: "conv5_3"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    engine: MKL2017
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu5_3"
+  type: "ReLU"
+  bottom: "conv5_3"
+  top: "conv5_3"
+  relu_param {
+    engine: MKL2017
+  }
+}
+layer {
+  name: "pool5"
+  type: "Pooling"
+  bottom: "conv5_3"
+  top: "pool5"
+  pooling_param {
+    engine: MKL2017
+    pool: MAX
+    kernel_size: 3
+    stride: 1
+    pad: 1
+  }
+}
+layer {
+  name: "fc6"
+  type: "Convolution"
+  bottom: "pool5"
+  top: "fc6"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 1024
+    pad: 6
+    kernel_size: 3
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+    dilation: 6
+  }
+}
+layer {
+  name: "relu6"
+  type: "ReLU"
+  bottom: "fc6"
+  top: "fc6"
+}
+layer {
+  name: "fc7"
+  type: "Convolution"
+  bottom: "fc6"
+  top: "fc7"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 1024
+    kernel_size: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "relu7"
+  type: "ReLU"
+  bottom: "fc7"
+  top: "fc7"
+}
+layer {
+  name: "conv6_1"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "conv6_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_1_relu"
+  type: "ReLU"
+  bottom: "conv6_1"
+  top: "conv6_1"
+}
+layer {
+  name: "conv6_2"
+  type: "Convolution"
+  bottom: "conv6_1"
+  top: "conv6_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 512
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_relu"
+  type: "ReLU"
+  bottom: "conv6_2"
+  top: "conv6_2"
+}
+layer {
+  name: "conv7_1"
+  type: "Convolution"
+  bottom: "conv6_2"
+  top: "conv7_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_1_relu"
+  type: "ReLU"
+  bottom: "conv7_1"
+  top: "conv7_1"
+}
+layer {
+  name: "conv7_2"
+  type: "Convolution"
+  bottom: "conv7_1"
+  top: "conv7_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_relu"
+  type: "ReLU"
+  bottom: "conv7_2"
+  top: "conv7_2"
+}
+layer {
+  name: "conv8_1"
+  type: "Convolution"
+  bottom: "conv7_2"
+  top: "conv8_1"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 128
+    pad: 0
+    kernel_size: 1
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_1_relu"
+  type: "ReLU"
+  bottom: "conv8_1"
+  top: "conv8_1"
+}
+layer {
+  name: "conv8_2"
+  type: "Convolution"
+  bottom: "conv8_1"
+  top: "conv8_2"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 256
+    pad: 1
+    kernel_size: 3
+    stride: 2
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_relu"
+  type: "ReLU"
+  bottom: "conv8_2"
+  top: "conv8_2"
+}
+layer {
+  name: "pool6"
+  type: "Pooling"
+  bottom: "conv8_2"
+  top: "pool6"
+  pooling_param {
+    pool: AVE
+    global_pooling: true
+  }
+}
+layer {
+  name: "conv4_3_norm"
+  type: "Normalize"
+  bottom: "conv4_3"
+  top: "conv4_3_norm"
+  norm_param {
+    across_spatial: false
+    scale_filler {
+      type: "constant"
+      value: 20
+    }
+    channel_shared: false
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc"
+  type: "Convolution"
+  bottom: "conv4_3_norm"
+  top: "conv4_3_norm_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 12
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv4_3_norm_mbox_loc"
+  top: "conv4_3_norm_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv4_3_norm_mbox_loc_perm"
+  top: "conv4_3_norm_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf"
+  type: "Convolution"
+  bottom: "conv4_3_norm"
+  top: "conv4_3_norm_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 63
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv4_3_norm_mbox_conf"
+  top: "conv4_3_norm_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv4_3_norm_mbox_conf_perm"
+  top: "conv4_3_norm_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv4_3_norm_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv4_3_norm"
+  bottom: "data"
+  top: "conv4_3_norm_mbox_priorbox"
+  prior_box_param {
+    min_size: 30.0
+    aspect_ratio: 2
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "fc7_mbox_loc"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "fc7_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "fc7_mbox_loc_perm"
+  type: "Permute"
+  bottom: "fc7_mbox_loc"
+  top: "fc7_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "fc7_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "fc7_mbox_loc_perm"
+  top: "fc7_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "fc7_mbox_conf"
+  type: "Convolution"
+  bottom: "fc7"
+  top: "fc7_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "fc7_mbox_conf_perm"
+  type: "Permute"
+  bottom: "fc7_mbox_conf"
+  top: "fc7_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "fc7_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "fc7_mbox_conf_perm"
+  top: "fc7_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "fc7_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "fc7"
+  bottom: "data"
+  top: "fc7_mbox_priorbox"
+  prior_box_param {
+    min_size: 60.0
+    max_size: 114.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv6_2"
+  top: "conv6_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv6_2_mbox_loc"
+  top: "conv6_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv6_2_mbox_loc_perm"
+  top: "conv6_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv6_2"
+  top: "conv6_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv6_2_mbox_conf"
+  top: "conv6_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv6_2_mbox_conf_perm"
+  top: "conv6_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv6_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv6_2"
+  bottom: "data"
+  top: "conv6_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 114.0
+    max_size: 168.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv7_2"
+  top: "conv7_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv7_2_mbox_loc"
+  top: "conv7_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv7_2_mbox_loc_perm"
+  top: "conv7_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv7_2"
+  top: "conv7_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv7_2_mbox_conf"
+  top: "conv7_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv7_2_mbox_conf_perm"
+  top: "conv7_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv7_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv7_2"
+  bottom: "data"
+  top: "conv7_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 168.0
+    max_size: 222.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc"
+  type: "Convolution"
+  bottom: "conv8_2"
+  top: "conv8_2_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc_perm"
+  type: "Permute"
+  bottom: "conv8_2_mbox_loc"
+  top: "conv8_2_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "conv8_2_mbox_loc_perm"
+  top: "conv8_2_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf"
+  type: "Convolution"
+  bottom: "conv8_2"
+  top: "conv8_2_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf_perm"
+  type: "Permute"
+  bottom: "conv8_2_mbox_conf"
+  top: "conv8_2_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "conv8_2_mbox_conf_perm"
+  top: "conv8_2_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "conv8_2_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "conv8_2"
+  bottom: "data"
+  top: "conv8_2_mbox_priorbox"
+  prior_box_param {
+    min_size: 222.0
+    max_size: 276.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "pool6_mbox_loc"
+  type: "Convolution"
+  bottom: "pool6"
+  top: "pool6_mbox_loc"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 24
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "pool6_mbox_loc_perm"
+  type: "Permute"
+  bottom: "pool6_mbox_loc"
+  top: "pool6_mbox_loc_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "pool6_mbox_loc_flat"
+  type: "Flatten"
+  bottom: "pool6_mbox_loc_perm"
+  top: "pool6_mbox_loc_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "pool6_mbox_conf"
+  type: "Convolution"
+  bottom: "pool6"
+  top: "pool6_mbox_conf"
+  param {
+    lr_mult: 1
+    decay_mult: 1
+  }
+  param {
+    lr_mult: 2
+    decay_mult: 0
+  }
+  convolution_param {
+    num_output: 126
+    pad: 1
+    kernel_size: 3
+    stride: 1
+    weight_filler {
+      type: "xavier"
+    }
+    bias_filler {
+      type: "constant"
+      value: 0
+    }
+  }
+}
+layer {
+  name: "pool6_mbox_conf_perm"
+  type: "Permute"
+  bottom: "pool6_mbox_conf"
+  top: "pool6_mbox_conf_perm"
+  permute_param {
+    order: 0
+    order: 2
+    order: 3
+    order: 1
+  }
+}
+layer {
+  name: "pool6_mbox_conf_flat"
+  type: "Flatten"
+  bottom: "pool6_mbox_conf_perm"
+  top: "pool6_mbox_conf_flat"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "pool6_mbox_priorbox"
+  type: "PriorBox"
+  bottom: "pool6"
+  bottom: "data"
+  top: "pool6_mbox_priorbox"
+  prior_box_param {
+    min_size: 276.0
+    max_size: 330.0
+    aspect_ratio: 2
+    aspect_ratio: 3
+    flip: true
+    clip: true
+    variance: 0.1
+    variance: 0.1
+    variance: 0.2
+    variance: 0.2
+  }
+}
+layer {
+  name: "mbox_loc"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_loc_flat"
+  bottom: "fc7_mbox_loc_flat"
+  bottom: "conv6_2_mbox_loc_flat"
+  bottom: "conv7_2_mbox_loc_flat"
+  bottom: "conv8_2_mbox_loc_flat"
+  bottom: "pool6_mbox_loc_flat"
+  top: "mbox_loc"
+  concat_param {
+    axis: 1
+  }
+}
+layer {
+  name: "mbox_conf"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_conf_flat"
+  bottom: "fc7_mbox_conf_flat"
+  bottom: "conv6_2_mbox_conf_flat"
+  bottom: "conv7_2_mbox_conf_flat"
+  bottom: "conv8_2_mbox_conf_flat"
+  bottom: "pool6_mbox_conf_flat"
+  top: "mbox_conf"
+  concat_param {
+    axis: 1
+  }
+}
+layer {
+  name: "mbox_priorbox"
+  type: "Concat"
+  bottom: "conv4_3_norm_mbox_priorbox"
+  bottom: "fc7_mbox_priorbox"
+  bottom: "conv6_2_mbox_priorbox"
+  bottom: "conv7_2_mbox_priorbox"
+  bottom: "conv8_2_mbox_priorbox"
+  bottom: "pool6_mbox_priorbox"
+  top: "mbox_priorbox"
+  concat_param {
+    axis: 2
+  }
+}
+layer {
+  name: "mbox_conf_reshape"
+  type: "Reshape"
+  bottom: "mbox_conf"
+  top: "mbox_conf_reshape"
+  reshape_param {
+    shape {
+      dim: 0
+      dim: -1
+      dim: 21
+    }
+  }
+}
+layer {
+  name: "mbox_conf_softmax"
+  type: "Softmax"
+  bottom: "mbox_conf_reshape"
+  top: "mbox_conf_softmax"
+  softmax_param {
+    axis: 2
+  }
+}
+layer {
+  name: "mbox_conf_flatten"
+  type: "Flatten"
+  bottom: "mbox_conf_softmax"
+  top: "mbox_conf_flatten"
+  flatten_param {
+    axis: 1
+  }
+}
+layer {
+  name: "detection_out"
+  type: "DetectionOutput"
+  bottom: "mbox_loc"
+  bottom: "mbox_conf_flatten"
+  bottom: "mbox_priorbox"
+  top: "detection_out"
+  include {
+    phase: TEST
+  }
+  detection_output_param {
+    num_classes: 21
+    share_location: true
+    background_label_id: 0
+    nms_param {
+      nms_threshold: 0.45
+      top_k: 400
+    }
+    code_type: CENTER_SIZE
+    keep_top_k: 200
+    confidence_threshold: 0.01
+  }
+}
+

--- a/examples/ssd/images.txt
+++ b/examples/ssd/images.txt
@@ -1,0 +1,1 @@
+examples/images/fish-bike.jpg

--- a/examples/ssd/readme.md
+++ b/examples/ssd/readme.md
@@ -1,0 +1,7 @@
+To run the SSD example:
+
+1) Prepare/Download the trained model, for example, download from http://www.cs.unc.edu/%7Ewliu/projects/SSD/models_VGGNet_VOC0712_SSD_300x300.tar.gz
+
+2) Run the SSD example: ./build/examples/ssd/ssd_detect.bin ./examples/ssd/deploy.prototxt models/VGGNet/VOC0712/SSD_300x300/VGG_VOC0712_SSD_300x300_iter_60000.caffemodel ./examples/ssd/images.txt
+
+Note: Please use the modified deploy.prototxt to get much better performance.

--- a/examples/ssd/ssd_detect.cpp
+++ b/examples/ssd/ssd_detect.cpp
@@ -1,0 +1,358 @@
+// This is a demo code for using a SSD model to do detection.
+// The code is modified from examples/cpp_classification/classification.cpp.
+// Usage:
+//    ssd_detect [FLAGS] model_file weights_file list_file
+//
+// where model_file is the .prototxt file defining the network architecture, and
+// weights_file is the .caffemodel file containing the network parameters, and
+// list_file contains a list of image files with the format as follows:
+//    folder/img1.JPEG
+//    folder/img2.JPEG
+// list_file can also contain a list of video files with the format as follows:
+//    folder/video1.mp4
+//    folder/video2.mp4
+//
+#include <caffe/caffe.hpp>
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+#include <algorithm>
+#include <iomanip>
+#include <iosfwd>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+#ifdef USE_OPENCV
+using namespace caffe;  // NOLINT(build/namespaces)
+
+class Detector {
+ public:
+  Detector(const string& model_file,
+           const string& weights_file,
+           const string& mean_file,
+           const string& mean_value);
+
+  std::vector<vector<float> > Detect(const cv::Mat& img);
+
+ private:
+  void SetMean(const string& mean_file, const string& mean_value);
+
+  void WrapInputLayer(std::vector<cv::Mat>* input_channels);
+
+  void Preprocess(const cv::Mat& img,
+                  std::vector<cv::Mat>* input_channels);
+
+ private:
+  shared_ptr<Net<float> > net_;
+  cv::Size input_geometry_;
+  int num_channels_;
+  cv::Mat mean_;
+};
+
+Detector::Detector(const string& model_file,
+                   const string& weights_file,
+                   const string& mean_file,
+                   const string& mean_value) {
+#ifdef CPU_ONLY
+  Caffe::set_mode(Caffe::CPU);
+#else
+  Caffe::set_mode(Caffe::GPU);
+#endif
+
+  /* Load the network. */
+  net_.reset(new Net<float>(model_file, TEST));
+  net_->CopyTrainedLayersFrom(weights_file);
+
+  CHECK_EQ(net_->num_inputs(), 1) << "Network should have exactly one input.";
+  CHECK_EQ(net_->num_outputs(), 1) << "Network should have exactly one output.";
+
+  Blob<float>* input_layer = net_->input_blobs()[0];
+  num_channels_ = input_layer->channels();
+  CHECK(num_channels_ == 3 || num_channels_ == 1)
+    << "Input layer should have 1 or 3 channels.";
+  input_geometry_ = cv::Size(input_layer->width(), input_layer->height());
+
+  /* Load the binaryproto mean file. */
+  SetMean(mean_file, mean_value);
+}
+
+std::vector<vector<float> > Detector::Detect(const cv::Mat& img) {
+  Blob<float>* input_layer = net_->input_blobs()[0];
+  input_layer->Reshape(1, num_channels_,
+                       input_geometry_.height, input_geometry_.width);
+  /* Forward dimension change to all layers. */
+  net_->Reshape();
+
+  std::vector<cv::Mat> input_channels;
+  WrapInputLayer(&input_channels);
+
+  Preprocess(img, &input_channels);
+
+  net_->Forward();
+
+  /* Copy the output layer to a std::vector */
+  Blob<float>* result_blob = net_->output_blobs()[0];
+  const float* result = result_blob->cpu_data();
+  const int num_det = result_blob->height();
+  vector<vector<float> > detections;
+  for (int k = 0; k < num_det; ++k) {
+    if (result[0] == -1) {
+      // Skip invalid detection.
+      result += 7;
+      continue;
+    }
+    vector<float> detection(result, result + 7);
+    detections.push_back(detection);
+    result += 7;
+  }
+  return detections;
+}
+
+/* Load the mean file in binaryproto format. */
+void Detector::SetMean(const string& mean_file, const string& mean_value) {
+  cv::Scalar channel_mean;
+  if (!mean_file.empty()) {
+    CHECK(mean_value.empty()) <<
+      "Cannot specify mean_file and mean_value at the same time";
+    BlobProto blob_proto;
+    ReadProtoFromBinaryFileOrDie(mean_file.c_str(), &blob_proto);
+
+    /* Convert from BlobProto to Blob<float> */
+    Blob<float> mean_blob;
+    mean_blob.FromProto(blob_proto);
+    CHECK_EQ(mean_blob.channels(), num_channels_)
+      << "Number of channels of mean file doesn't match input layer.";
+
+    /* The format of the mean file is planar 32-bit float BGR or grayscale. */
+    std::vector<cv::Mat> channels;
+    float* data = mean_blob.mutable_cpu_data();
+    for (int i = 0; i < num_channels_; ++i) {
+      /* Extract an individual channel. */
+      cv::Mat channel(mean_blob.height(), mean_blob.width(), CV_32FC1, data);
+      channels.push_back(channel);
+      data += mean_blob.height() * mean_blob.width();
+    }
+
+    /* Merge the separate channels into a single image. */
+    cv::Mat mean;
+    cv::merge(channels, mean);
+
+    /* Compute the global mean pixel value and create a mean image
+     * filled with this value. */
+    channel_mean = cv::mean(mean);
+    mean_ = cv::Mat(input_geometry_, mean.type(), channel_mean);
+  }
+  if (!mean_value.empty()) {
+    CHECK(mean_file.empty()) <<
+      "Cannot specify mean_file and mean_value at the same time";
+    stringstream ss(mean_value);
+    vector<float> values;
+    string item;
+    while (getline(ss, item, ',')) {
+      float value = std::atof(item.c_str());
+      values.push_back(value);
+    }
+    CHECK(values.size() == 1 || values.size() == num_channels_) <<
+      "Specify either 1 mean_value or as many as channels: " << num_channels_;
+
+    std::vector<cv::Mat> channels;
+    for (int i = 0; i < num_channels_; ++i) {
+      /* Extract an individual channel. */
+      cv::Mat channel(input_geometry_.height, input_geometry_.width, CV_32FC1,
+          cv::Scalar(values[i]));
+      channels.push_back(channel);
+    }
+    cv::merge(channels, mean_);
+  }
+}
+
+/* Wrap the input layer of the network in separate cv::Mat objects
+ * (one per channel). This way we save one memcpy operation and we
+ * don't need to rely on cudaMemcpy2D. The last preprocessing
+ * operation will write the separate channels directly to the input
+ * layer. */
+void Detector::WrapInputLayer(std::vector<cv::Mat>* input_channels) {
+  Blob<float>* input_layer = net_->input_blobs()[0];
+
+  int width = input_layer->width();
+  int height = input_layer->height();
+  float* input_data = input_layer->mutable_cpu_data();
+  for (int i = 0; i < input_layer->channels(); ++i) {
+    cv::Mat channel(height, width, CV_32FC1, input_data);
+    input_channels->push_back(channel);
+    input_data += width * height;
+  }
+}
+
+void Detector::Preprocess(const cv::Mat& img,
+                            std::vector<cv::Mat>* input_channels) {
+  /* Convert the input image to the input image format of the network. */
+  cv::Mat sample;
+  if (img.channels() == 3 && num_channels_ == 1)
+    cv::cvtColor(img, sample, cv::COLOR_BGR2GRAY);
+  else if (img.channels() == 4 && num_channels_ == 1)
+    cv::cvtColor(img, sample, cv::COLOR_BGRA2GRAY);
+  else if (img.channels() == 4 && num_channels_ == 3)
+    cv::cvtColor(img, sample, cv::COLOR_BGRA2BGR);
+  else if (img.channels() == 1 && num_channels_ == 3)
+    cv::cvtColor(img, sample, cv::COLOR_GRAY2BGR);
+  else
+    sample = img;
+
+  cv::Mat sample_resized;
+  if (sample.size() != input_geometry_)
+    cv::resize(sample, sample_resized, input_geometry_);
+  else
+    sample_resized = sample;
+
+  cv::Mat sample_float;
+  if (num_channels_ == 3)
+    sample_resized.convertTo(sample_float, CV_32FC3);
+  else
+    sample_resized.convertTo(sample_float, CV_32FC1);
+
+  cv::Mat sample_normalized;
+  cv::subtract(sample_float, mean_, sample_normalized);
+
+  /* This operation will write the separate BGR planes directly to the
+   * input layer of the network because it is wrapped by the cv::Mat
+   * objects in input_channels. */
+  cv::split(sample_normalized, *input_channels);
+
+  CHECK(reinterpret_cast<float*>(input_channels->at(0).data)
+        == net_->input_blobs()[0]->cpu_data())
+    << "Input channels are not wrapping the input layer of the network.";
+}
+
+DEFINE_string(mean_file, "",
+    "The mean file used to subtract from the input image.");
+DEFINE_string(mean_value, "104,117,123",
+    "If specified, can be one value or can be same as image channels"
+    " - would subtract from the corresponding channel). Separated by ','."
+    "Either mean_file or mean_value should be provided, not both.");
+DEFINE_string(file_type, "image",
+    "The file type in the list_file. Currently support image and video.");
+DEFINE_string(out_file, "",
+    "If provided, store the detection results in the out_file.");
+DEFINE_double(confidence_threshold, 0.01,
+    "Only store detections with score higher than the threshold.");
+
+int main(int argc, char** argv) {
+  ::google::InitGoogleLogging(argv[0]);
+  // Print output to stderr (while still logging)
+  FLAGS_alsologtostderr = 1;
+
+#ifndef GFLAGS_GFLAGS_H_
+  namespace gflags = google;
+#endif
+
+  gflags::SetUsageMessage("Do detection using SSD mode.\n"
+        "Usage:\n"
+        "    ssd_detect [FLAGS] model_file weights_file list_file\n");
+  gflags::ParseCommandLineFlags(&argc, &argv, true);
+
+  if (argc < 4) {
+    gflags::ShowUsageWithFlagsRestrict(argv[0], "examples/ssd/ssd_detect");
+    return 1;
+  }
+
+  const string& model_file = argv[1];
+  const string& weights_file = argv[2];
+  const string& mean_file = FLAGS_mean_file;
+  const string& mean_value = FLAGS_mean_value;
+  const string& file_type = FLAGS_file_type;
+  const string& out_file = FLAGS_out_file;
+  const float confidence_threshold = FLAGS_confidence_threshold;
+
+  // Initialize the network.
+  Detector detector(model_file, weights_file, mean_file, mean_value);
+
+  // Set the output mode.
+  std::streambuf* buf = std::cout.rdbuf();
+  std::ofstream outfile;
+  if (!out_file.empty()) {
+    outfile.open(out_file.c_str());
+    if (outfile.good()) {
+      buf = outfile.rdbuf();
+    }
+  }
+  std::ostream out(buf);
+
+  // Process image one by one.
+  std::ifstream infile(argv[3]);
+  std::string file;
+  while (infile >> file) {
+    if (file_type == "image") {
+      cv::Mat img = cv::imread(file, -1);
+      CHECK(!img.empty()) << "Unable to decode image " << file;
+      std::vector<vector<float> > detections = detector.Detect(img);
+
+      /* Print the detection results. */
+      for (int i = 0; i < detections.size(); ++i) {
+        const vector<float>& d = detections[i];
+        // Detection format: [image_id, label, score, xmin, ymin, xmax, ymax].
+        CHECK_EQ(d.size(), 7);
+        const float score = d[2];
+        if (score >= confidence_threshold) {
+          out << file << " ";
+          out << static_cast<int>(d[1]) << " ";
+          out << score << " ";
+          out << static_cast<int>(d[3] * img.cols) << " ";
+          out << static_cast<int>(d[4] * img.rows) << " ";
+          out << static_cast<int>(d[5] * img.cols) << " ";
+          out << static_cast<int>(d[6] * img.rows) << std::endl;
+        }
+      }
+    } else if (file_type == "video") {
+      cv::VideoCapture cap(file);
+      if (!cap.isOpened()) {
+        LOG(FATAL) << "Failed to open video: " << file;
+      }
+      cv::Mat img;
+      int frame_count = 0;
+      while (true) {
+        bool success = cap.read(img);
+        if (!success) {
+          LOG(INFO) << "Process " << frame_count << " frames from " << file;
+          break;
+        }
+        CHECK(!img.empty()) << "Error when read frame";
+        std::vector<vector<float> > detections = detector.Detect(img);
+
+        /* Print the detection results. */
+        for (int i = 0; i < detections.size(); ++i) {
+          const vector<float>& d = detections[i];
+          // Detection format: [image_id, label, score, xmin, ymin, xmax, ymax].
+          CHECK_EQ(d.size(), 7);
+          const float score = d[2];
+          if (score >= confidence_threshold) {
+            out << file << "_";
+            out << std::setfill('0') << std::setw(6) << frame_count << " ";
+            out << static_cast<int>(d[1]) << " ";
+            out << score << " ";
+            out << static_cast<int>(d[3] * img.cols) << " ";
+            out << static_cast<int>(d[4] * img.rows) << " ";
+            out << static_cast<int>(d[5] * img.cols) << " ";
+            out << static_cast<int>(d[6] * img.rows) << std::endl;
+          }
+        }
+        ++frame_count;
+      }
+      if (cap.isOpened()) {
+        cap.release();
+      }
+    } else {
+      LOG(FATAL) << "Unknown file_type: " << file_type;
+    }
+  }
+  return 0;
+}
+#else
+int main(int argc, char** argv) {
+  LOG(FATAL) << "This example requires OpenCV; compile with USE_OPENCV.";
+}
+#endif  // USE_OPENCV

--- a/include/caffe/data_reader.hpp
+++ b/include/caffe/data_reader.hpp
@@ -1,46 +1,8 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #ifndef CAFFE_DATA_READER_HPP_
 #define CAFFE_DATA_READER_HPP_
 
 #include <map>
 #include <string>
-#include <utility>
 #include <vector>
 
 #include "caffe/common.hpp"
@@ -58,15 +20,16 @@ namespace caffe {
  * subset of the database. Data is distributed to solvers in a round-robin
  * way to keep parallel training deterministic.
  */
+template <typename T>
 class DataReader {
  public:
   explicit DataReader(const LayerParameter& param);
   ~DataReader();
 
-  inline BlockingQueue<std::string*>& free() const {
+  inline BlockingQueue<T*>& free() const {
     return queue_pair_->free_;
   }
-  inline BlockingQueue<std::string*>& full() const {
+  inline BlockingQueue<T*>& full() const {
     return queue_pair_->full_;
   }
 
@@ -77,43 +40,10 @@ class DataReader {
     explicit QueuePair(int size);
     ~QueuePair();
 
-    BlockingQueue<std::string*> free_;
-    BlockingQueue<std::string*> full_;
+    BlockingQueue<T*> free_;
+    BlockingQueue<T*> full_;
 
   DISABLE_COPY_AND_ASSIGN(QueuePair);
-  };
-
-  class DBWrapper  {
-   public:
-    explicit DBWrapper(const LayerParameter& param);
-    virtual string value() = 0;
-    virtual void Next() = 0;
-   protected:
-    shared_ptr<db::DB> db;
-    shared_ptr<db::Cursor> cursor;
-  };
-
-  class DBShuffle: public DBWrapper {
-   public:
-    explicit DBShuffle(const LayerParameter& param);
-    virtual string value() {
-      return string(static_cast<const char*>(current_image_->first),
-                                                      current_image_->second);
-    }
-    virtual void Next();
-   protected:
-    vector<std::pair<void*, int> > image_pointers_;
-    vector<std::pair<void*, int> >::iterator current_image_;
-    shared_ptr<Caffe::RNG> prefetch_rng_;
-
-    void ShuffleImages();
-  };
-
-  class DBSequential: public DBWrapper {
-   public:
-    explicit DBSequential(const LayerParameter& param): DBWrapper(param)  {}
-    virtual string value()  { return cursor->value(); }
-    virtual void Next();
   };
 
   // A single body is created per source
@@ -124,8 +54,7 @@ class DataReader {
 
    protected:
     void InternalThreadEntry();
-    void read_one(DBWrapper* img, QueuePair* qp);
-    void ShuffleImages();
+    void read_one(db::Cursor* cursor, QueuePair* qp);
 
     const LayerParameter param_;
     BlockingQueue<shared_ptr<QueuePair> > new_queue_pairs_;
@@ -144,7 +73,7 @@ class DataReader {
   const shared_ptr<QueuePair> queue_pair_;
   shared_ptr<Body> body_;
 
-  static map<const string, boost::weak_ptr<DataReader::Body> > bodies_;
+  static map<const string, boost::weak_ptr<Body> > bodies_;
 
 DISABLE_COPY_AND_ASSIGN(DataReader);
 };

--- a/include/caffe/data_transformer.hpp
+++ b/include/caffe/data_transformer.hpp
@@ -1,110 +1,17 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #ifndef CAFFE_DATA_TRANSFORMER_HPP
 #define CAFFE_DATA_TRANSFORMER_HPP
 
-#include <queue>
 #include <vector>
+
+#include "google/protobuf/repeated_field.h"
 
 #include "caffe/blob.hpp"
 #include "caffe/common.hpp"
 #include "caffe/proto/caffe.pb.h"
-#include "caffe/util/math_functions.hpp"
-#include "caffe/util/rng.hpp"
 
-
+using google::protobuf::RepeatedPtrField;
 
 namespace caffe {
-
-class DataReader;
-
-class RandNumbers {
- public:
-   /**
-   * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
-   *
-   * @param n
-   *    The upperbound (exclusive) value of the random number.
-   * @return
-   *    A uniformly random integer value from ({0, 1, ..., n-1}).
-   */
-  int operator()(int n) {
-    CHECK_GT(n, 0);
-    return GetNextNumber() % n;
-  }
-
-  virtual uint32_t GetNextNumber() = 0;
-};
-
-class GenRandNumbers: public RandNumbers {
- public:
-  void Init() {
-    const unsigned int rng_seed = caffe_rng_rand();
-    rng_.reset(new Caffe::RNG(rng_seed));
-  }
-  void Reset() { rng_.reset(); }
-  virtual uint32_t GetNextNumber() {
-    CHECK(rng_);
-    caffe::rng_t* rng = static_cast<caffe::rng_t*>(rng_->generator());
-    return (*rng)();
-  }
- private:
-  shared_ptr<Caffe::RNG> rng_;
-};
-
-
-class PreclcRandomNumbers: public RandNumbers {
- public:
-  void FillRandomNumbers(int num_count, RandNumbers& rand_gen) {
-    for (int i = 0; i < num_count; i++)
-      random_numbers.push(rand_gen.GetNextNumber());
-  }
-
-  virtual uint32_t GetNextNumber() {
-    CHECK(!random_numbers.empty());
-    uint32_t num = random_numbers.front();
-    random_numbers.pop();
-    return num;
-  }
- private:
-  std::queue<uint32_t> random_numbers;
-};
-
 
 /**
  * @brief Applies common transformations to the input data, such as
@@ -122,8 +29,6 @@ class DataTransformer {
    */
   void InitRand();
 
-  void GenerateRandNumbers(PreclcRandomNumbers& rn);
-
   /**
    * @brief Applies the transformation defined in the data layer's
    * transform_param block to the data.
@@ -134,11 +39,7 @@ class DataTransformer {
    *    This is destination blob. It can be part of top blob's data if
    *    set_cpu_data() is used. See data_layer.cpp for an example.
    */
-
-  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob)
-                               {Transform(datum, transformed_blob, rand_num_);}
-  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob,
-                                                       RandNumbers& rand_num);
+  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob);
 
   /**
    * @brief Applies the transformation defined in the data layer's
@@ -152,6 +53,63 @@ class DataTransformer {
    */
   void Transform(const vector<Datum> & datum_vector,
                 Blob<Dtype>* transformed_blob);
+
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the annotated data.
+   *
+   * @param anno_datum
+   *    AnnotatedDatum containing the data and annotation to be transformed.
+   * @param transformed_blob
+   *    This is destination blob. It can be part of top blob's data if
+   *    set_cpu_data() is used. See annotated_data_layer.cpp for an example.
+   * @param transformed_anno_vec
+   *    This is destination annotation.
+   */
+  void Transform(const AnnotatedDatum& anno_datum,
+                 Blob<Dtype>* transformed_blob,
+                 RepeatedPtrField<AnnotationGroup>* transformed_anno_vec);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 Blob<Dtype>* transformed_blob,
+                 RepeatedPtrField<AnnotationGroup>* transformed_anno_vec,
+                 bool* do_mirror);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 Blob<Dtype>* transformed_blob,
+                 vector<AnnotationGroup>* transformed_anno_vec,
+                 bool* do_mirror);
+  void Transform(const AnnotatedDatum& anno_datum,
+                 Blob<Dtype>* transformed_blob,
+                 vector<AnnotationGroup>* transformed_anno_vec);
+
+  /**
+   * @brief Transform the annotation according to the transformation applied
+   * to the datum.
+   *
+   * @param anno_datum
+   *    AnnotatedDatum containing the data and annotation to be transformed.
+   * @param crop_bbox
+   *    The cropped region applied to anno_datum.datum()
+   * @param do_mirror
+   *    If true, meaning the datum has mirrored.
+   * @param transformed_anno_group_all
+   *    Stores all transformed AnnotationGroup.
+   */
+  void TransformAnnotation(
+      const AnnotatedDatum& anno_datum,
+      const NormalizedBBox& crop_bbox, const bool do_mirror,
+      RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all);
+
+  /**
+   * @brief Crops the datum according to bbox.
+   */
+  void CropImage(const Datum& datum, const NormalizedBBox& bbox,
+                 Datum* crop_datum);
+
+  /**
+   * @brief Crops the datum and AnnotationGroup according to bbox.
+   */
+  void CropImage(const AnnotatedDatum& anno_datum, const NormalizedBBox& bbox,
+                 AnnotatedDatum* cropped_anno_datum);
 
 #ifdef USE_OPENCV
   /**
@@ -177,12 +135,19 @@ class DataTransformer {
    *    This is destination blob. It can be part of top blob's data if
    *    set_cpu_data() is used. See image_data_layer.cpp for an example.
    */
-
-  void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob)
-                               {Transform(cv_img, transformed_blob, rand_num_);}
   void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob,
-                                                         RandNumbers& rand_num);
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
+  void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob);
 
+  /**
+   * @brief Crops img according to bbox.
+   */
+  void CropImage(const cv::Mat& img, const NormalizedBBox& bbox,
+                 cv::Mat* crop_img);
+
+  void TransformInv(const Blob<Dtype>* blob, vector<cv::Mat>* cv_imgs);
+  void TransformInv(const Dtype* data, cv::Mat* cv_img, const int height,
+                    const int width, const int channels);
 #endif  // USE_OPENCV
 
   /**
@@ -236,30 +201,36 @@ class DataTransformer {
 #endif  // USE_OPENCV
 
  protected:
-  GenRandNumbers rand_num_;
+   /**
+   * @brief Generates a random integer from Uniform({0, 1, ..., n-1}).
+   *
+   * @param n
+   *    The upperbound (exclusive) value of the random number.
+   * @return
+   *    A uniformly random integer value from ({0, 1, ..., n-1}).
+   */
+  virtual int Rand(int n);
 
+  // Transform and return the transformation information.
   void Transform(const Datum& datum, Dtype* transformed_data,
-                                                    RandNumbers& rand_num);
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
+  void Transform(const Datum& datum, Dtype* transformed_data);
+
+  /**
+   * @brief Applies the transformation defined in the data layer's
+   * transform_param block to the data and return transform information.
+   */
+  void Transform(const Datum& datum, Blob<Dtype>* transformed_blob,
+                 NormalizedBBox* crop_bbox, bool* do_mirror);
+
   // Tranformation parameters
   TransformationParameter param_;
 
+
+  shared_ptr<Caffe::RNG> rng_;
   Phase phase_;
   Blob<Dtype> data_mean_;
   vector<Dtype> mean_values_;
-
-  // Data reader used if any to get data
-  DataReader* data_reader_used;
-
-
- private:
-  template<bool do_mirror, bool has_mean_file, bool has_mean_values>
-  void Transform(const cv::Mat& cv_img, Blob<Dtype>* transformed_blob,
-                                                         RandNumbers& rand_num);
-
-  template<bool has_uint8,  bool do_mirror, bool has_mean_file,
-          bool has_mean_values>
-  void Transform(const Datum& datum, Dtype* transformed_data,
-                                                         RandNumbers& rand_num);
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/annotated_data_layer.hpp
+++ b/include/caffe/layers/annotated_data_layer.hpp
@@ -1,6 +1,7 @@
 #ifndef CAFFE_DATA_LAYER_HPP_
 #define CAFFE_DATA_LAYER_HPP_
 
+#include <string>
 #include <vector>
 
 #include "caffe/blob.hpp"
@@ -15,23 +16,26 @@
 namespace caffe {
 
 template <typename Dtype>
-class DataLayer : public BasePrefetchingDataLayer<Dtype> {
+class AnnotatedDataLayer : public BasePrefetchingDataLayer<Dtype> {
  public:
-  explicit DataLayer(const LayerParameter& param);
-  virtual ~DataLayer();
+  explicit AnnotatedDataLayer(const LayerParameter& param);
+  virtual ~AnnotatedDataLayer();
   virtual void DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top);
-  // DataLayer uses DataReader instead for sharing for parallelism
+  // AnnotatedDataLayer uses DataReader instead for sharing for parallelism
   virtual inline bool ShareInParallel() const { return false; }
-  virtual inline const char* type() const { return "Data"; }
+  virtual inline const char* type() const { return "AnnotatedData"; }
   virtual inline int ExactNumBottomBlobs() const { return 0; }
   virtual inline int MinTopBlobs() const { return 1; }
-  virtual inline int MaxTopBlobs() const { return 2; }
 
  protected:
   virtual void load_batch(Batch<Dtype>* batch);
 
-  DataReader<Datum> reader_;
+  DataReader<AnnotatedDatum> reader_;
+  bool has_anno_type_;
+  AnnotatedDatum_AnnotationType anno_type_;
+  vector<BatchSampler> batch_samplers_;
+  string label_map_file_;
 };
 
 }  // namespace caffe

--- a/include/caffe/layers/detection_evaluate_layer.hpp
+++ b/include/caffe/layers/detection_evaluate_layer.hpp
@@ -1,0 +1,68 @@
+#ifndef CAFFE_DETECTION_EVALUATE_LAYER_HPP_
+#define CAFFE_DETECTION_EVALUATE_LAYER_HPP_
+
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Generate the detection evaluation based on DetectionOutputLayer and
+ * ground truth bounding box labels.
+ *
+ * Intended for use with MultiBox detection method.
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Dtype>
+class DetectionEvaluateLayer : public Layer<Dtype> {
+ public:
+  explicit DetectionEvaluateLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "DetectionEvaluate"; }
+  virtual inline int ExactBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Evaluate the detection output.
+   *
+   * @param bottom input Blob vector (exact 2)
+   *   -# @f$ (1 \times 1 \times N \times 7) @f$
+   *      N detection results.
+   *   -# @f$ (1 \times 1 \times M \times 7) @f$
+   *      M ground truth.
+   * @param top Blob vector (length 1)
+   *   -# @f$ (1 \times 1 \times N \times 4) @f$
+   *      N is the number of detections, and each row is:
+   *      [image_id, label, confidence, true_pos, false_pos]
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+
+  int num_classes_;
+  int background_label_id_;
+  float overlap_threshold_;
+  bool evaluate_difficult_gt_;
+  vector<pair<int, int> > sizes_;
+  int count_;
+  bool use_normalized_bbox_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DETECTION_EVALUATE_LAYER_HPP_

--- a/include/caffe/layers/detection_output_layer.hpp
+++ b/include/caffe/layers/detection_output_layer.hpp
@@ -1,0 +1,111 @@
+#ifndef CAFFE_DETECTION_OUTPUT_LAYER_HPP_
+#define CAFFE_DETECTION_OUTPUT_LAYER_HPP_
+
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/regex.hpp>
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/data_transformer.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+#include "caffe/util/bbox_util.hpp"
+
+using namespace boost::property_tree;  // NOLINT(build/namespaces)
+
+namespace caffe {
+
+/**
+ * @brief Generate the detection output based on location and confidence
+ * predictions by doing non maximum suppression.
+ *
+ * Intended for use with MultiBox detection method.
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Dtype>
+class DetectionOutputLayer : public Layer<Dtype> {
+ public:
+  explicit DetectionOutputLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "DetectionOutput"; }
+  virtual inline int MinBottomBlobs() const { return 3; }
+  virtual inline int MaxBottomBlobs() const { return 4; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Do non maximum suppression (nms) on prediction results.
+   *
+   * @param bottom input Blob vector (at least 2)
+   *   -# @f$ (N \times C1 \times 1 \times 1) @f$
+   *      the location predictions with C1 predictions.
+   *   -# @f$ (N \times C2 \times 1 \times 1) @f$
+   *      the confidence predictions with C2 predictions.
+   *   -# @f$ (N \times 2 \times C3 \times 1) @f$
+   *      the prior bounding boxes with C3 values.
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (1 \times 1 \times N \times 7) @f$
+   *      N is the number of detections after nms, and each row is:
+   *      [image_id, label, confidence, xmin, ymin, xmax, ymax]
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    NOT_IMPLEMENTED;
+  }
+
+  int num_classes_;
+  bool share_location_;
+  int num_loc_classes_;
+  int background_label_id_;
+  CodeType code_type_;
+  bool variance_encoded_in_target_;
+  int keep_top_k_;
+  float confidence_threshold_;
+
+  int num_;
+  int num_priors_;
+
+  float nms_threshold_;
+  int top_k_;
+
+  bool need_save_;
+  string output_directory_;
+  string output_name_prefix_;
+  string output_format_;
+  map<int, string> label_to_name_;
+  map<int, string> label_to_display_name_;
+  vector<string> names_;
+  vector<pair<int, int> > sizes_;
+  int num_test_image_;
+  int name_count_;
+
+  ptree detections_;
+
+  bool visualize_;
+  float visualize_threshold_;
+  shared_ptr<DataTransformer<Dtype> > data_transformer_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_DETECTION_OUTPUT_LAYER_HPP_

--- a/include/caffe/layers/normalize_layer.hpp
+++ b/include/caffe/layers/normalize_layer.hpp
@@ -1,0 +1,51 @@
+#ifndef CAFFE_NORMALIZE_LAYER_HPP_
+#define CAFFE_NORMALIZE_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Normalizes the input to have L_p norm of 1 with scale learnable.
+ *
+ * TODO(weiliu89): thorough documentation for Forward, Backward, and proto params.
+ */
+template <typename Dtype>
+class NormalizeLayer : public Layer<Dtype> {
+ public:
+  explicit NormalizeLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "Normalize"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+     const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  Blob<Dtype> norm_;
+  Blob<Dtype> sum_channel_multiplier_, sum_spatial_multiplier_;
+  Blob<Dtype> buffer_, buffer_channel_, buffer_spatial_;
+  bool across_spatial_;
+  bool channel_shared_;
+  Dtype eps_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_MVN_LAYER_HPP_

--- a/include/caffe/layers/permute_layer.hpp
+++ b/include/caffe/layers/permute_layer.hpp
@@ -1,0 +1,59 @@
+#ifndef CAFFE_PERMUTE_LAYER_HPP_
+#define CAFFE_PERMUTE_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Permute the input blob by changing the memory order of the data.
+ *
+ * TODO(weiliu89): thorough documentation for Forward, Backward, and proto params.
+ */
+
+// The main function which does the permute.
+template <typename Dtype>
+void Permute(const int count, Dtype* bottom_data, const bool forward,
+    const int* permute_order, const int* old_steps, const int* new_steps,
+    const int num_axes, Dtype* top_data);
+
+template <typename Dtype>
+class PermuteLayer : public Layer<Dtype> {
+ public:
+  explicit PermuteLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "Permute"; }
+  virtual inline int ExactNumBottomBlobs() const { return 1; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Forward_gpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+  virtual void Backward_gpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom);
+
+  int num_axes_;
+  bool need_permute_;
+
+  // Use Blob because it is convenient to be accessible in .cu file.
+  Blob<int> permute_order_;
+  Blob<int> old_steps_;
+  Blob<int> new_steps_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_PERMUTE_LAYER_HPP_

--- a/include/caffe/layers/prior_box_layer.hpp
+++ b/include/caffe/layers/prior_box_layer.hpp
@@ -1,0 +1,76 @@
+#ifndef CAFFE_PRIORBOX_LAYER_HPP_
+#define CAFFE_PRIORBOX_LAYER_HPP_
+
+#include <vector>
+
+#include "caffe/blob.hpp"
+#include "caffe/layer.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+/**
+ * @brief Generate the prior boxes of designated sizes and aspect ratios across
+ *        all dimensions @f$ (H \times W) @f$.
+ *
+ * Intended for use with MultiBox detection method to generate prior (template).
+ *
+ * NOTE: does not implement Backwards operation.
+ */
+template <typename Dtype>
+class PriorBoxLayer : public Layer<Dtype> {
+ public:
+  /**
+   * @param param provides PriorBoxParameter prior_box_param,
+   *     with PriorBoxLayer options:
+   *   - min_size (\b minimum box size in pixels. required!).
+   *   - max_size (\b maximum box size in pixels. required!).
+   *   - aspect_ratio (\b optional aspect ratios of the boxes. can be multiple).
+   *   - flip (\b optional bool, default true).
+   *     if set, flip the aspect ratio.
+   */
+  explicit PriorBoxLayer(const LayerParameter& param)
+      : Layer<Dtype>(param) {}
+  virtual void LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  virtual void Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+
+  virtual inline const char* type() const { return "PriorBox"; }
+  virtual inline int ExactBottomBlobs() const { return 2; }
+  virtual inline int ExactNumTopBlobs() const { return 1; }
+
+ protected:
+  /**
+   * @brief Generates prior boxes for a layer with specified parameters.
+   *
+   * @param bottom input Blob vector (at least 2)
+   *   -# @f$ (N \times C \times H_i \times W_i) @f$
+   *      the input layer @f$ x_i @f$
+   *   -# @f$ (N \times C \times H_0 \times W_0) @f$
+   *      the data layer @f$ x_0 @f$
+   * @param top output Blob vector (length 1)
+   *   -# @f$ (N \times 2 \times K*4) @f$ where @f$ K @f$ is the prior numbers
+   *   By default, a box of aspect ratio 1 and min_size and a box of aspect
+   *   ratio 1 and sqrt(min_size * max_size) are created.
+   */
+  virtual void Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top);
+  /// @brief Not implemented
+  virtual void Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+    return;
+  }
+
+  float min_size_;
+  float max_size_;
+  vector<float> aspect_ratios_;
+  bool flip_;
+  int num_priors_;
+  bool clip_;
+  vector<float> variance_;
+};
+
+}  // namespace caffe
+
+#endif  // CAFFE_PRIORBOX_LAYER_HPP_

--- a/include/caffe/util/bbox_util.hpp
+++ b/include/caffe/util/bbox_util.hpp
@@ -1,0 +1,332 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#include <opencv2/highgui/highgui.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+#endif  // USE_OPENCV
+
+#ifndef CAFFE_UTIL_BBOX_UTIL_H_
+#define CAFFE_UTIL_BBOX_UTIL_H_
+
+#include <stdint.h>
+#include <cmath>  // for std::fabs and std::signbit
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "caffe/caffe.hpp"
+
+namespace caffe {
+
+typedef EmitConstraint_EmitType EmitType;
+typedef PriorBoxParameter_CodeType CodeType;
+typedef MultiBoxLossParameter_MatchType MatchType;
+typedef MultiBoxLossParameter_LocLossType LocLossType;
+typedef MultiBoxLossParameter_ConfLossType ConfLossType;
+
+typedef map<int, vector<NormalizedBBox> > LabelBBox;
+
+// Function used to sort NormalizedBBox, stored in STL container (e.g. vector),
+// in ascend order based on the score value.
+bool SortBBoxAscend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Function used to sort NormalizedBBox, stored in STL container (e.g. vector),
+// in descend order based on the score value.
+bool SortBBoxDescend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Function sued to sort pair<float, T>, stored in STL container (e.g. vector)
+// in descend order based on the score (first) value.
+template <typename T>
+bool SortScorePairAscend(const pair<float, T>& pair1,
+                         const pair<float, T>& pair2);
+
+// Function sued to sort pair<float, T>, stored in STL container (e.g. vector)
+// in descend order based on the score (first) value.
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2);
+
+// Generate unit bbox [0, 0, 1, 1]
+NormalizedBBox UnitBBox();
+
+// Compute the intersection between two bboxes.
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox);
+
+// Compute bbox size.
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized = true);
+
+// Clip the NormalizedBBox such that the range for each corner is [0, 1].
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox);
+
+// Scale the NormalizedBBox w.r.t. height and width.
+void ScaleBBox(const NormalizedBBox& bbox, const int height, const int width,
+               NormalizedBBox* scale_bbox);
+
+// Locate bbox in the coordinate system that src_bbox sits.
+void LocateBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                NormalizedBBox* loc_bbox);
+
+// Project bbox onto the coordinate system defined by src_bbox.
+bool ProjectBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                 NormalizedBBox* proj_bbox);
+
+// Compute the jaccard (intersection over union IoU) overlap between two bboxes.
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized = true);
+
+// Compute the coverage of bbox1 by bbox2.
+float BBoxCoverage(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2);
+
+// Encode a bbox according to a prior bbox.
+void EncodeBBox(const NormalizedBBox& prior_bbox,
+    const vector<float>& prior_variance, const CodeType code_type,
+    const bool encode_variance_in_target, const NormalizedBBox& bbox,
+    NormalizedBBox* encode_bbox);
+
+// Check if a bbox meet emit constraint w.r.t. src_bbox.
+bool MeetEmitConstraint(const NormalizedBBox& src_bbox,
+    const NormalizedBBox& bbox, const EmitConstraint& emit_constraint);
+
+// Decode a bbox according to a prior bbox.
+void DecodeBBox(const NormalizedBBox& prior_bbox,
+    const vector<float>& prior_variance, const CodeType code_type,
+    const bool variance_encoded_in_target, const NormalizedBBox& bbox,
+    NormalizedBBox* decode_bbox);
+
+// Decode a set of bboxes according to a set of prior bboxes.
+void DecodeBBoxes(const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes);
+
+// Decode all bboxes in a batch.
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_pred,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    vector<LabelBBox>* all_decode_bboxes);
+
+// Match prediction bboxes with ground truth bboxes.
+void MatchBBox(const vector<NormalizedBBox>& gt,
+    const vector<NormalizedBBox>& pred_bboxes, const int label,
+    const MatchType match_type, const float overlap_threshold,
+    vector<int>* match_indices, vector<float>* match_overlaps);
+
+// Retrieve bounding box ground truth from gt_data.
+//    gt_data: 1 x 1 x num_gt x 7 blob.
+//    num_gt: the number of ground truth.
+//    background_label_id: the label for background class which is used to do
+//      santity check so that no ground truth contains it.
+//    all_gt_bboxes: stores ground truth for each image. Label of each bbox is
+//      stored in NormalizedBBox.
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+// Store ground truth bboxes of same label in a group.
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+
+// Get location predictions from loc_data.
+//    loc_data: num x num_preds_per_class * num_loc_classes * 4 blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_loc_classes: number of location classes. It is 1 if share_location is
+//      true; and is equal to number of classes needed to predict otherwise.
+//    share_location: if true, all classes share the same location prediction.
+//    loc_preds: stores the location prediction, where each item contains
+//      location prediction for an image.
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+// Get confidence predictions from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    conf_preds: stores the confidence prediction, where each item contains
+//      confidence prediction for an image.
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_scores);
+
+// Get confidence predictions from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    class_major: if true, data layout is
+//      num x num_classes x num_preds_per_class; otherwise, data layerout is
+//      num x num_preds_per_class * num_classes.
+//    conf_preds: stores the confidence prediction, where each item contains
+//      confidence prediction for an image.
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_scores);
+
+// Get max confidence scores for each prior from conf_data.
+//    conf_data: num x num_preds_per_class * num_classes blob.
+//    num: the number of images.
+//    num_preds_per_class: number of predictions per class.
+//    num_classes: number of classes.
+//    background_label_id: it is used to skip selecting max scores from
+//      background class.
+//    loss_type: compute the probability according to the loss type.
+//    all_max_scores: stores the max confidence per location for each image.
+template <typename Dtype>
+void GetMaxConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_max_scores);
+
+// Get prior bounding boxes from prior_data.
+//    prior_data: 1 x 2 x num_priors * 4 x 1 blob.
+//    num_priors: number of priors.
+//    prior_bboxes: stores all the prior bboxes in the format of NormalizedBBox.
+//    prior_variances: stores all the variances needed by prior bboxes.
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+
+// Get detection results from det_data.
+//    det_data: 1 x 1 x num_det x 7 blob.
+//    num_det: the number of detections.
+//    background_label_id: the label for background class which is used to do
+//      santity check so that no detection contains it.
+//    all_detections: stores detection results for each class from each image.
+template <typename Dtype>
+void GetDetectionResults(const Dtype* det_data, const int num_det,
+      const int background_label_id,
+      map<int, LabelBBox>* all_detections);
+
+// Get top_k scores with corresponding indices.
+//    scores: a set of scores.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetTopKScoreIndex(const vector<float>& scores, const int top_k,
+                         vector<pair<float, int> >* score_index_vec);
+
+// Get max scores with corresponding indices.
+//    scores: a set of scores.
+//    threshold: only consider scores higher than the threshold.
+//    top_k: if -1, keep all; otherwise, keep at most top_k.
+//    score_index_vec: store the sorted (score, index) pair.
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec);
+
+// Do non maximum suppression given bboxes and scores.
+//    bboxes: a set of bounding boxes.
+//    scores: a set of corresponding confidences.
+//    threshold: the threshold used in non maximu suppression.
+//    top_k: if not -1, keep at most top_k picked indices.
+//    reuse_overlaps: if true, use and update overlaps; otherwise, always
+//      compute overlap.
+//    overlaps: a temp place to optionally store the overlaps between pairs of
+//      bboxes if reuse_overlaps is true.
+//    indices: the kept indices of bboxes after nms.
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, const bool reuse_overlaps,
+      map<int, map<int, float> >* overlaps, vector<int>* indices);
+
+void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices);
+
+// Do non maximum suppression given bboxes and scores.
+// Inspired by Piotr Dollar's NMS implementation in EdgeBox.
+// https://goo.gl/jV3JYS
+//    bboxes: a set of bounding boxes.
+//    scores: a set of corresponding confidences.
+//    score_threshold: a threshold used to filter detection results.
+//    nms_threshold: a threshold used in non maximum suppression.
+//    top_k: if not -1, keep at most top_k picked indices.
+//    indices: the kept indices of bboxes after nms.
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const int top_k, vector<int>* indices);
+
+// Compute cumsum of a set of pairs.
+void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum);
+
+// Compute average precision given true positive and false positive vectors.
+//    tp: contains pairs of scores and true positive.
+//    num_pos: number of positives.
+//    fp: contains pairs of scores and false positive.
+//    ap_version: different ways of computing Average Precision.
+//      Check https://sanchom.wordpress.com/tag/average-precision/ for details.
+//      11point: the 11-point interpolated average precision. Used in VOC2007.
+//      MaxIntegral: maximally interpolated AP. Used in VOC2012/ILSVRC.
+//      Integral: the natural integral of the precision-recall curve.
+//    prec: stores the computed precisions.
+//    rec: stores the computed recalls.
+//    ap: the computed Average Precision.
+void ComputeAP(const vector<pair<float, int> >& tp, const int num_pos,
+               const vector<pair<float, int> >& fp, const string ap_version,
+               vector<float>* prec, vector<float>* rec, float* ap);
+
+#ifndef CPU_ONLY  // GPU
+template <typename Dtype>
+__host__ __device__ Dtype BBoxSizeGPU(const Dtype* bbox,
+                                      const bool normalized = true);
+
+template <typename Dtype>
+__host__ __device__ Dtype JaccardOverlapGPU(const Dtype* bbox1,
+                                            const Dtype* bbox2);
+
+template <typename Dtype>
+void DecodeBBoxesGPU(const int nthreads,
+          const Dtype* loc_data, const Dtype* prior_data,
+          const CodeType code_type, const bool variance_encoded_in_target,
+          const int num_priors, const bool share_location,
+          const int num_loc_classes, const int background_label_id,
+          Dtype* bbox_data);
+
+template <typename Dtype>
+void PermuteDataGPU(const int nthreads,
+          const Dtype* data, const int num_classes, const int num_data,
+          const int num_dim, Dtype* new_data);
+
+template <typename Dtype>
+void ComputeOverlappedGPU(const int nthreads,
+          const Dtype* bbox_data, const int num_bboxes, const int num_classes,
+          const Dtype overlap_threshold, bool* overlapped_data);
+
+template <typename Dtype>
+void ComputeOverlappedByIdxGPU(const int nthreads,
+          const Dtype* bbox_data, const Dtype overlap_threshold,
+          const int* idx, const int num_idx, bool* overlapped_data);
+
+template <typename Dtype>
+void ApplyNMSGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int num_bboxes, const float confidence_threshold,
+          const int top_k, const float nms_threshold, vector<int>* indices);
+
+template <typename Dtype>
+void GetDetectionsGPU(const Dtype* bbox_data, const Dtype* conf_data,
+          const int image_id, const int label, const vector<int>& indices,
+          const bool clip_bbox, Blob<Dtype>* detection_blob);
+#endif  // !CPU_ONLY
+
+#ifdef USE_OPENCV
+vector<cv::Scalar> GetColors(const int n);
+
+template <typename Dtype>
+void VisualizeBBox(const vector<cv::Mat>& images, const Blob<Dtype>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name);
+#endif  // USE_OPENCV
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_BBOX_UTIL_H_

--- a/include/caffe/util/im_transforms.hpp
+++ b/include/caffe/util/im_transforms.hpp
@@ -1,0 +1,55 @@
+#ifdef USE_OPENCV
+#ifndef IM_TRANSFORMS_HPP
+#define IM_TRANSFORMS_HPP
+
+#include <opencv2/core/core.hpp>
+#include <opencv2/imgproc/imgproc.hpp>
+
+#include <vector>
+
+#include "caffe/common.hpp"
+#include "caffe/proto/caffe.pb.h"
+
+namespace caffe {
+
+// Generate random number given the probablities for each number.
+int roll_weighted_die(const std::vector<float>& probabilities);
+
+template <typename T>
+bool is_border(const cv::Mat& edge, T color);
+
+// Auto cropping image.
+template <typename T>
+cv::Rect CropMask(const cv::Mat& src, T point, int padding = 2);
+
+cv::Mat colorReduce(const cv::Mat& image, int div = 64);
+
+void fillEdgeImage(const cv::Mat& edgesIn, cv::Mat* filledEdgesOut);
+
+void CenterObjectAndFillBg(const cv::Mat& in_img, const bool fill_bg,
+                           cv::Mat* out_img);
+
+cv::Mat AspectKeepingResizeAndPad(const cv::Mat& in_img,
+                                  const int new_width, const int new_height,
+                                  const int pad_type = cv::BORDER_CONSTANT,
+                                  const cv::Scalar pad = cv::Scalar(0, 0, 0),
+                                  const int interp_mode = cv::INTER_LINEAR);
+
+cv::Mat AspectKeepingResizeBySmall(const cv::Mat& in_img,
+                                   const int new_width, const int new_height,
+                                   const int interp_mode = cv::INTER_LINEAR);
+
+void constantNoise(const int n, const vector<uchar>& val, cv::Mat* image);
+
+void UpdateBBoxByResizePolicy(const ResizeParameter& param,
+                              const int old_width, const int old_height,
+                              NormalizedBBox* bbox);
+
+cv::Mat ApplyResize(const cv::Mat& in_img, const ResizeParameter& param);
+
+cv::Mat ApplyNoise(const cv::Mat& in_img, const NoiseParameter& param);
+
+}  // namespace caffe
+
+#endif  // IM_TRANSFORMS_HPP
+#endif  // USE_OPENCV

--- a/include/caffe/util/io.hpp
+++ b/include/caffe/util/io.hpp
@@ -1,46 +1,10 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #ifndef CAFFE_UTIL_IO_H_
 #define CAFFE_UTIL_IO_H_
 
 #include <boost/filesystem.hpp>
 #include <iomanip>
 #include <iostream>  // NOLINT(readability/streams)
+#include <map>
 #include <string>
 
 #include "google/protobuf/message.h"
@@ -80,6 +44,38 @@ inline void MakeTempFilename(string* temp_filename) {
   if ( temp_files_subpath.empty() ) {
     string path_string="";
     MakeTempDir(&path_string);
+    temp_files_subpath = path_string;
+  }
+  *temp_filename =
+    (temp_files_subpath/caffe::format_int(next_temp_file++, 9)).string();
+}
+
+inline void GetTempDirname(string* temp_dirname) {
+  temp_dirname->clear();
+  const path& model =
+    boost::filesystem::temp_directory_path()/"caffe_test.%%%%-%%%%";
+  for ( int i = 0; i < CAFFE_TMP_DIR_RETRIES; i++ ) {
+    const path& dir = boost::filesystem::unique_path(model).string();
+    bool done = boost::filesystem::create_directory(dir);
+    if ( done ) {
+      bool remove_done = boost::filesystem::remove(dir);
+      if (remove_done) {
+        *temp_dirname = dir.string();
+        return;
+      }
+      LOG(FATAL) << "Failed to remove a temporary directory.";
+    }
+  }
+  LOG(FATAL) << "Failed to create a temporary directory.";
+}
+
+inline void GetTempFilename(string* temp_filename) {
+  static path temp_files_subpath;
+  static uint64_t next_temp_file = 0;
+  temp_filename->clear();
+  if ( temp_files_subpath.empty() ) {
+    string path_string="";
+    GetTempDirname(&path_string);
     temp_files_subpath = path_string;
   }
   *temp_filename =
@@ -134,8 +130,29 @@ inline bool ReadFileToDatum(const string& filename, Datum* datum) {
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, const std::string & encoding, Datum* datum);
+
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, min_dim, max_dim,
+                          is_color, "", datum);
+}
+
+inline bool ReadImageToDatum(const string& filename, const int label,
+    const int height, const int width, const int min_dim, const int max_dim,
+    Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, min_dim, max_dim,
+                          true, datum);
+}
+
+inline bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, const bool is_color,
-    const std::string & encoding, Datum* datum);
+    const std::string & encoding, Datum* datum) {
+  return ReadImageToDatum(filename, label, height, width, 0, 0, is_color,
+                          encoding, datum);
+}
 
 inline bool ReadImageToDatum(const string& filename, const int label,
     const int height, const int width, const bool is_color, Datum* datum) {
@@ -166,7 +183,80 @@ inline bool ReadImageToDatum(const string& filename, const int label,
 bool DecodeDatumNative(Datum* datum);
 bool DecodeDatum(Datum* datum, bool is_color);
 
+
+void GetImageSize(const string& filename, int* height, int* width);
+
+bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelname, const int height, const int width,
+    const int min_dim, const int max_dim, const bool is_color,
+    const std::string& encoding, const AnnotatedDatum_AnnotationType type,
+    const string& labeltype, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+inline bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelname, const int height, const int width,
+    const bool is_color, const std::string & encoding,
+    const AnnotatedDatum_AnnotationType type, const string& labeltype,
+    const std::map<string, int>& name_to_label, AnnotatedDatum* anno_datum) {
+  return ReadRichImageToAnnotatedDatum(filename, labelname, height, width, 0, 0,
+                      is_color, encoding, type, labeltype, name_to_label,
+                      anno_datum);
+}
+
+bool ReadXMLToAnnotatedDatum(const string& labelname, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+bool ReadJSONToAnnotatedDatum(const string& labelname, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum);
+
+bool ReadTxtToAnnotatedDatum(const string& labelname, const int height,
+    const int width, AnnotatedDatum* anno_datum);
+
+bool ReadLabelFileToLabelMap(const string& filename, bool include_background,
+    const string& delimiter, LabelMap* map);
+
+inline bool ReadLabelFileToLabelMap(const string& filename,
+      bool include_background, LabelMap* map) {
+  return ReadLabelFileToLabelMap(filename, include_background, " ", map);
+}
+
+inline bool ReadLabelFileToLabelMap(const string& filename, LabelMap* map) {
+  return ReadLabelFileToLabelMap(filename, true, map);
+}
+
+bool MapNameToLabel(const LabelMap& map, const bool strict_check,
+                    std::map<string, int>* name_to_label);
+
+inline bool MapNameToLabel(const LabelMap& map,
+                           std::map<string, int>* name_to_label) {
+  return MapNameToLabel(map, true, name_to_label);
+}
+
+bool MapLabelToName(const LabelMap& map, const bool strict_check,
+                    std::map<int, string>* label_to_name);
+
+inline bool MapLabelToName(const LabelMap& map,
+                           std::map<int, string>* label_to_name) {
+  return MapLabelToName(map, true, label_to_name);
+}
+
+bool MapLabelToDisplayName(const LabelMap& map, const bool strict_check,
+                           std::map<int, string>* label_to_display_name);
+
+inline bool MapLabelToDisplayName(const LabelMap& map,
+                              std::map<int, string>* label_to_display_name) {
+  return MapLabelToDisplayName(map, true, label_to_display_name);
+}
+
 #ifdef USE_OPENCV
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim, const bool is_color);
+
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim);
+
 cv::Mat ReadImageToCVMat(const string& filename,
     const int height, const int width, const bool is_color);
 
@@ -180,6 +270,9 @@ cv::Mat ReadImageToCVMat(const string& filename);
 
 cv::Mat DecodeDatumToCVMatNative(const Datum& datum);
 cv::Mat DecodeDatumToCVMat(const Datum& datum, bool is_color);
+
+void EncodeCVMatToDatum(const cv::Mat& cv_img, const string& encoding,
+                        Datum* datum);
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum);
 #endif  // USE_OPENCV

--- a/include/caffe/util/sampler.hpp
+++ b/include/caffe/util/sampler.hpp
@@ -1,0 +1,39 @@
+#ifndef CAFFE_UTIL_SAMPLER_H_
+#define CAFFE_UTIL_SAMPLER_H_
+
+#include <vector>
+
+#include "glog/logging.h"
+
+#include "caffe/caffe.hpp"
+
+namespace caffe {
+
+// Find all annotated NormalizedBBox.
+void GroupObjectBBoxes(const AnnotatedDatum& anno_datum,
+                       vector<NormalizedBBox>* object_bboxes);
+
+// Check if a sampled bbox satisfy the constraints with all object bboxes.
+bool SatisfySampleConstraint(const NormalizedBBox& sampled_bbox,
+                             const vector<NormalizedBBox>& object_bboxes,
+                             const SampleConstraint& sample_constraint);
+
+// Sample a NormalizedBBox given the specifictions.
+void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox);
+
+// Generate samples from NormalizedBBox using the BatchSampler.
+void GenerateSamples(const NormalizedBBox& source_bbox,
+                     const vector<NormalizedBBox>& object_bboxes,
+                     const BatchSampler& batch_sampler,
+                     vector<NormalizedBBox>* sampled_bboxes);
+
+// Generate samples from AnnotatedDatum using the BatchSampler.
+// All sampled bboxes which satisfy the constraints defined in BatchSampler
+// is stored in sampled_bboxes.
+void GenerateBatchSamples(const AnnotatedDatum& anno_datum,
+                          const vector<BatchSampler>& batch_samplers,
+                          vector<NormalizedBBox>* sampled_bboxes);
+
+}  // namespace caffe
+
+#endif  // CAFFE_UTIL_SAMPLER_H_

--- a/src/caffe/data_reader.cpp
+++ b/src/caffe/data_reader.cpp
@@ -1,40 +1,3 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #include <boost/thread.hpp>
 #include <map>
 #include <string>
@@ -42,6 +5,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "caffe/common.hpp"
 #include "caffe/data_reader.hpp"
+#include "caffe/layers/annotated_data_layer.hpp"
 #include "caffe/layers/data_layer.hpp"
 #include "caffe/proto/caffe.pb.h"
 
@@ -49,10 +13,21 @@ namespace caffe {
 
 using boost::weak_ptr;
 
-map<const string, weak_ptr<DataReader::Body> > DataReader::bodies_;
+// It has to explicitly initialize the map<> in order to work. It seems to be a
+// gcc bug.
+// http://www.cplusplus.com/forum/beginner/31576/
+template <>
+map<const string, weak_ptr<DataReader<Datum>::Body> >
+  DataReader<Datum>::bodies_
+  = map<const string, weak_ptr<DataReader<Datum>::Body> >();
+template <>
+map<const string, weak_ptr<DataReader<AnnotatedDatum>::Body> >
+  DataReader<AnnotatedDatum>::bodies_
+  = map<const string, weak_ptr<DataReader<AnnotatedDatum>::Body> >();
 static boost::mutex bodies_mutex_;
 
-DataReader::DataReader(const LayerParameter& param)
+template <typename T>
+DataReader<T>::DataReader(const LayerParameter& param)
     : queue_pair_(new QueuePair(  //
         param.data_param().prefetch() * param.data_param().batch_size())) {
   // Get or create a body
@@ -67,7 +42,8 @@ DataReader::DataReader(const LayerParameter& param)
   body_->new_queue_pairs_.push(queue_pair_);
 }
 
-DataReader::~DataReader() {
+template <typename T>
+DataReader<T>::~DataReader() {
   string key = source_key(body_->param_);
   body_.reset();
   boost::mutex::scoped_lock lock(bodies_mutex_);
@@ -76,45 +52,42 @@ DataReader::~DataReader() {
   }
 }
 
-//
-
-DataReader::QueuePair::QueuePair(int size) {
-  // Initialize the free queue with requested number of datums
+template <typename T>
+DataReader<T>::QueuePair::QueuePair(int size) {
+  // Initialize the free queue with requested number of data
   for (int i = 0; i < size; ++i) {
-    free_.push(new string("empty buffer"));
+    free_.push(new T());
   }
 }
 
-DataReader::QueuePair::~QueuePair() {
-  string* datum;
-  while (free_.try_pop(&datum)) {
-    delete datum;
+template <typename T>
+DataReader<T>::QueuePair::~QueuePair() {
+  T* t;
+  while (free_.try_pop(&t)) {
+    delete t;
   }
-  while (full_.try_pop(&datum)) {
-    delete datum;
+  while (full_.try_pop(&t)) {
+    delete t;
   }
 }
 
-//
-
-DataReader::Body::Body(const LayerParameter& param)
+template <typename T>
+DataReader<T>::Body::Body(const LayerParameter& param)
     : param_(param),
       new_queue_pairs_() {
   StartInternalThread();
 }
 
-DataReader::Body::~Body() {
+template <typename T>
+DataReader<T>::Body::~Body() {
   StopInternalThread();
 }
 
-void DataReader::Body::InternalThreadEntry() {
-  const caffe::DataParameter *data_param = &param_.data_param();
-  CHECK(data_param) << "Failed to obtain data_param";
-
-  shared_ptr<DBWrapper> dbw(data_param->shuffle() ?
-                        static_cast<DBWrapper*>(new DBShuffle(param_)):
-                        static_cast<DBWrapper*>(new DBSequential(param_)));
-
+template <typename T>
+void DataReader<T>::Body::InternalThreadEntry() {
+  shared_ptr<db::DB> db(db::GetDB(param_.data_param().backend()));
+  db->Open(param_.data_param().source(), db::READ);
+  shared_ptr<db::Cursor> cursor(db->NewCursor());
   vector<shared_ptr<QueuePair> > qps;
   try {
     int solver_count = param_.phase() == TRAIN ? Caffe::solver_count() : 1;
@@ -124,13 +97,13 @@ void DataReader::Body::InternalThreadEntry() {
     // so read one item, then wait for the next solver.
     for (int i = 0; i < solver_count; ++i) {
       shared_ptr<QueuePair> qp(new_queue_pairs_.pop());
-      read_one(dbw.get(), qp.get());
+      read_one(cursor.get(), qp.get());
       qps.push_back(qp);
     }
     // Main loop
     while (!must_stop()) {
       for (int i = 0; i < solver_count; ++i) {
-        read_one(dbw.get(), qps[i].get());
+        read_one(cursor.get(), qps[i].get());
       }
       // Check no additional readers have been created. This can happen if
       // more than one net is trained at a time per process, whether single
@@ -143,58 +116,14 @@ void DataReader::Body::InternalThreadEntry() {
   }
 }
 
-void DataReader::Body::read_one(DBWrapper* dbw, QueuePair* qp) {
-  CHECK(dbw);
-  CHECK(qp);
-
-  string* data = qp->free_.pop();
+template <typename T>
+void DataReader<T>::Body::read_one(db::Cursor* cursor, QueuePair* qp) {
+  T* t = qp->free_.pop();
   // TODO deserialize in-place instead of copy?
-  *data = dbw->value();
-  qp->full_.push(data);
+  t->ParseFromString(cursor->value());
+  qp->full_.push(t);
 
-  dbw->Next();
-}
-
-
-
-DataReader::DBWrapper::DBWrapper(const LayerParameter& param) {
-  db.reset(db::GetDB(param.data_param().backend()));
-  db->Open(param.data_param().source(), db::READ);
-  cursor.reset(db->NewCursor());
-}
-
-DataReader::DBShuffle::DBShuffle(const LayerParameter& param):DBWrapper(param) {
-  CHECK(param.data_param().backend() != DataParameter_DB_LEVELDB)
-                                      << "LevelDB doesn't support shuffle";
-  while (cursor->valid()) {
-    image_pointers_.push_back(cursor->valuePointer());
-    cursor->Next();
-  }
-  CHECK(!image_pointers_.empty());
-  current_image_ = image_pointers_.begin();
-
-  // randomly shuffle data
-  LOG(INFO) << "Shuffling data";
-  const unsigned int prefetch_rng_seed = caffe_rng_rand();
-  prefetch_rng_.reset(new Caffe::RNG(prefetch_rng_seed));
-  ShuffleImages();
-}
-
-void DataReader::DBShuffle::Next() {
-  current_image_++;
-  if (current_image_ == image_pointers_.end()) {
-    ShuffleImages();
-    current_image_ = image_pointers_.begin();
-  }
-}
-
-void DataReader::DBShuffle::ShuffleImages() {
-  caffe::rng_t* prefetch_rng =
-      static_cast<caffe::rng_t*>(prefetch_rng_->generator());
-  shuffle(image_pointers_.begin(), image_pointers_.end(), prefetch_rng);
-}
-
-void DataReader::DBSequential::Next() {
+  // go to the next iter
   cursor->Next();
   if (!cursor->valid()) {
     DLOG(INFO) << "Restarting data prefetching from start.";
@@ -202,6 +131,8 @@ void DataReader::DBSequential::Next() {
   }
 }
 
-
+// Instance class
+template class DataReader<Datum>;
+template class DataReader<AnnotatedDatum>;
 
 }  // namespace caffe

--- a/src/caffe/data_transformer.cpp
+++ b/src/caffe/data_transformer.cpp
@@ -1,58 +1,24 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #ifdef USE_OPENCV
 #include <opencv2/core/core.hpp>
+
+#include "caffe/util/im_transforms.hpp"
 #endif  // USE_OPENCV
 
 #include <string>
 #include <vector>
 
-#include "caffe/data_reader.hpp"
 #include "caffe/data_transformer.hpp"
+#include "caffe/util/bbox_util.hpp"
 #include "caffe/util/io.hpp"
-
+#include "caffe/util/math_functions.hpp"
+#include "caffe/util/rng.hpp"
 
 namespace caffe {
 
 template<typename Dtype>
 DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
     Phase phase)
-    : param_(param), phase_(phase), data_reader_used(NULL) {
+    : param_(param), phase_(phase) {
   // check if we want to use mean_file
   if (param_.has_mean_file()) {
     CHECK_EQ(param_.mean_value_size(), 0) <<
@@ -75,67 +41,11 @@ DataTransformer<Dtype>::DataTransformer(const TransformationParameter& param,
   }
 }
 
-
 template<typename Dtype>
-
 void DataTransformer<Dtype>::Transform(const Datum& datum,
-                         Dtype* transformed_data, RandNumbers& rand_num) {
-  const bool do_mirror = param_.mirror() && rand_num(2);
-  const string& data = datum.data();
-  const bool has_uint8 = data.size() > 0;
-  const bool has_mean_file = param_.has_mean_file();
-  const bool has_mean_values = mean_values_.size() > 0;
-
-  int transform_func_id = (do_mirror << 2) +
-                          (has_mean_file << 1) +
-                          has_mean_values;
-
-  if (!has_uint8) {
-    switch (transform_func_id) {
-        case 0: Transform<false, false, false, false>(datum, transformed_data,
-          rand_num); break;
-        case 1: Transform<false, false, false, true >(datum, transformed_data,
-          rand_num); break;
-        case 2: Transform<false, false, true , false>(datum, transformed_data,
-          rand_num); break;
-        case 3: Transform<false, false, true , true >(datum, transformed_data,
-          rand_num); break;
-        case 4: Transform<false, true , false, false>(datum, transformed_data,
-          rand_num); break;
-        case 5: Transform<false, true , false, true >(datum, transformed_data,
-          rand_num); break;
-        case 6: Transform<false, true , true , false>(datum, transformed_data,
-          rand_num); break;
-        case 7: Transform<false, true , true , true >(datum, transformed_data,
-          rand_num); break;
-    }
-  } else {
-    switch (transform_func_id) {
-        case 0: Transform<true, false, false, false>(datum, transformed_data,
-          rand_num); break;
-        case 1: Transform<true, false, false, true >(datum, transformed_data,
-          rand_num); break;
-        case 2: Transform<true, false, true , false>(datum, transformed_data,
-          rand_num); break;
-        case 3: Transform<true, false, true , true >(datum, transformed_data,
-          rand_num); break;
-        case 4: Transform<true, true , false, false>(datum, transformed_data,
-          rand_num); break;
-        case 5: Transform<true, true , false, true >(datum, transformed_data,
-          rand_num); break;
-        case 6: Transform<true, true , true , false>(datum, transformed_data,
-          rand_num); break;
-        case 7: Transform<true, true , true , true >(datum, transformed_data,
-          rand_num); break;
-    }
-  }
-}
-
-template<typename Dtype>
-template<bool has_uint8, bool do_mirror, bool has_mean_file,
-  bool has_mean_values>
-void DataTransformer<Dtype>::Transform(const Datum& datum,
-                         Dtype* transformed_data, RandNumbers& rand_num) {
+                                       Dtype* transformed_data,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
   const string& data = datum.data();
   const int datum_channels = datum.channels();
   const int datum_height = datum.height();
@@ -143,6 +53,10 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 
   const int crop_size = param_.crop_size();
   const Dtype scale = param_.scale();
+  *do_mirror = param_.mirror() && Rand(2);
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_uint8 = data.size() > 0;
+  const bool has_mean_values = mean_values_.size() > 0;
 
   CHECK_GT(datum_channels, 0);
   CHECK_GE(datum_height, crop_size);
@@ -176,13 +90,19 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     width = crop_size;
     // We only do random crop when we do training.
     if (phase_ == TRAIN) {
-      h_off = rand_num(datum_height - crop_size + 1);
-      w_off = rand_num(datum_width - crop_size + 1);
+      h_off = Rand(datum_height - crop_size + 1);
+      w_off = Rand(datum_width - crop_size + 1);
     } else {
       h_off = (datum_height - crop_size) / 2;
       w_off = (datum_width - crop_size) / 2;
     }
   }
+
+  // Return the normalized crop bbox.
+  crop_bbox->set_xmin(Dtype(w_off) / datum_width);
+  crop_bbox->set_ymin(Dtype(h_off) / datum_height);
+  crop_bbox->set_xmax(Dtype(w_off + width) / datum_width);
+  crop_bbox->set_ymax(Dtype(h_off + height) / datum_height);
 
   Dtype datum_element;
   int top_index, data_index;
@@ -190,7 +110,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
     for (int h = 0; h < height; ++h) {
       for (int w = 0; w < width; ++w) {
         data_index = (c * datum_height + h_off + h) * datum_width + w_off + w;
-        if (do_mirror) {
+        if (*do_mirror) {
           top_index = (c * height + h) * width + (width - 1 - w);
         } else {
           top_index = (c * height + h) * width + w;
@@ -218,15 +138,18 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
 }
 
 template<typename Dtype>
-void DataTransformer<Dtype>::GenerateRandNumbers(PreclcRandomNumbers& rn) {
-  int count = (param_.mirror()? 1:0) +
-                  ((phase_ == TRAIN && param_.crop_size())? 2 : 0);
-  rn.FillRandomNumbers(count, rand_num_);
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       Dtype* transformed_data) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(datum, transformed_data, &crop_bbox, &do_mirror);
 }
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const Datum& datum,
-               Blob<Dtype>* transformed_blob, RandNumbers& rand_num) {
+                                       Blob<Dtype>* transformed_blob,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
   // If datum is encoded, decoded and transform the cv::image.
   if (datum.encoded()) {
 #ifdef USE_OPENCV
@@ -240,7 +163,7 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
       cv_img = DecodeDatumToCVMatNative(datum);
     }
     // Transform the cv::image into blob.
-    return Transform(cv_img, transformed_blob, rand_num);
+    return Transform(cv_img, transformed_blob, crop_bbox, do_mirror);
 #else
     LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
 #endif  // USE_OPENCV
@@ -275,7 +198,15 @@ void DataTransformer<Dtype>::Transform(const Datum& datum,
   }
 
   Dtype* transformed_data = transformed_blob->mutable_cpu_data();
-  Transform(datum, transformed_data, rand_num);
+  Transform(datum, transformed_data, crop_bbox, do_mirror);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const Datum& datum,
+                                       Blob<Dtype>* transformed_blob) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(datum, transformed_blob, &crop_bbox, &do_mirror);
 }
 
 template<typename Dtype>
@@ -296,6 +227,181 @@ void DataTransformer<Dtype>::Transform(const vector<Datum> & datum_vector,
     uni_blob.set_cpu_data(transformed_blob->mutable_cpu_data() + offset);
     Transform(datum_vector[item_id], &uni_blob);
   }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, Blob<Dtype>* transformed_blob,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all,
+    bool* do_mirror) {
+  // Transform datum.
+  const Datum& datum = anno_datum.datum();
+  NormalizedBBox crop_bbox;
+  Transform(datum, transformed_blob, &crop_bbox, do_mirror);
+
+  // Transform annotation.
+  TransformAnnotation(anno_datum, crop_bbox, *do_mirror,
+                      transformed_anno_group_all);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, Blob<Dtype>* transformed_blob,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all) {
+  bool do_mirror;
+  Transform(anno_datum, transformed_blob, transformed_anno_group_all,
+            &do_mirror);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, Blob<Dtype>* transformed_blob,
+    vector<AnnotationGroup>* transformed_anno_vec, bool* do_mirror) {
+  RepeatedPtrField<AnnotationGroup> transformed_anno_group_all;
+  Transform(anno_datum, transformed_blob, &transformed_anno_group_all,
+            do_mirror);
+  for (int g = 0; g < transformed_anno_group_all.size(); ++g) {
+    transformed_anno_vec->push_back(transformed_anno_group_all.Get(g));
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(
+    const AnnotatedDatum& anno_datum, Blob<Dtype>* transformed_blob,
+    vector<AnnotationGroup>* transformed_anno_vec) {
+  bool do_mirror;
+  Transform(anno_datum, transformed_blob, transformed_anno_vec, &do_mirror);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformAnnotation(
+    const AnnotatedDatum& anno_datum,
+    const NormalizedBBox& crop_bbox, const bool do_mirror,
+    RepeatedPtrField<AnnotationGroup>* transformed_anno_group_all) {
+  if (anno_datum.type() == AnnotatedDatum_AnnotationType_BBOX) {
+    // Go through each AnnotationGroup.
+    for (int g = 0; g < anno_datum.annotation_group_size(); ++g) {
+      const AnnotationGroup& anno_group = anno_datum.annotation_group(g);
+      AnnotationGroup transformed_anno_group;
+      // Go through each Annotation.
+      bool has_valid_annotation = false;
+      for (int a = 0; a < anno_group.annotation_size(); ++a) {
+        const Annotation& anno = anno_group.annotation(a);
+        const NormalizedBBox& bbox = anno.bbox();
+        if (param_.has_emit_constraint() &&
+            !MeetEmitConstraint(crop_bbox, bbox, param_.emit_constraint())) {
+          continue;
+        }
+        // Adjust bounding box annotation.
+        NormalizedBBox proj_bbox;
+        if (ProjectBBox(crop_bbox, bbox, &proj_bbox)) {
+          has_valid_annotation = true;
+          Annotation* transformed_anno =
+              transformed_anno_group.add_annotation();
+          transformed_anno->set_instance_id(anno.instance_id());
+          NormalizedBBox* transformed_bbox = transformed_anno->mutable_bbox();
+          transformed_bbox->CopyFrom(proj_bbox);
+          if (do_mirror) {
+            Dtype temp = transformed_bbox->xmin();
+            transformed_bbox->set_xmin(1 - transformed_bbox->xmax());
+            transformed_bbox->set_xmax(1 - temp);
+          }
+        }
+      }
+      // Save for output.
+      if (has_valid_annotation) {
+        transformed_anno_group.set_group_label(anno_group.group_label());
+        transformed_anno_group_all->Add()->CopyFrom(transformed_anno_group);
+      }
+    }
+  } else {
+    LOG(FATAL) << "Unknown annotation type.";
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::CropImage(const Datum& datum,
+                                       const NormalizedBBox& bbox,
+                                       Datum* crop_datum) {
+  // If datum is encoded, decode and crop the cv::image.
+  if (datum.encoded()) {
+#ifdef USE_OPENCV
+    CHECK(!(param_.force_color() && param_.force_gray()))
+        << "cannot set both force_color and force_gray";
+    cv::Mat cv_img;
+    if (param_.force_color() || param_.force_gray()) {
+      // If force_color then decode in color otherwise decode in gray.
+      cv_img = DecodeDatumToCVMat(datum, param_.force_color());
+    } else {
+      cv_img = DecodeDatumToCVMatNative(datum);
+    }
+    // Crop the image.
+    cv::Mat crop_img;
+    CropImage(cv_img, bbox, &crop_img);
+    // Save the image into datum.
+    EncodeCVMatToDatum(crop_img, "jpg", crop_datum);
+    crop_datum->set_label(datum.label());
+    return;
+#else
+    LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
+#endif  // USE_OPENCV
+  } else {
+    if (param_.force_color() || param_.force_gray()) {
+      LOG(ERROR) << "force_color and force_gray only for encoded datum";
+    }
+  }
+
+  const int datum_channels = datum.channels();
+  const int datum_height = datum.height();
+  const int datum_width = datum.width();
+
+  // Get the bbox dimension.
+  NormalizedBBox clipped_bbox;
+  ClipBBox(bbox, &clipped_bbox);
+  NormalizedBBox scaled_bbox;
+  ScaleBBox(clipped_bbox, datum_height, datum_width, &scaled_bbox);
+  const int w_off = static_cast<int>(scaled_bbox.xmin());
+  const int h_off = static_cast<int>(scaled_bbox.ymin());
+  const int width = static_cast<int>(scaled_bbox.xmax() - scaled_bbox.xmin());
+  const int height = static_cast<int>(scaled_bbox.ymax() - scaled_bbox.ymin());
+
+  // Crop the image using bbox.
+  crop_datum->set_channels(datum_channels);
+  crop_datum->set_height(height);
+  crop_datum->set_width(width);
+  crop_datum->set_label(datum.label());
+  crop_datum->clear_data();
+  crop_datum->clear_float_data();
+  crop_datum->set_encoded(false);
+  const int crop_datum_size = datum_channels * height * width;
+  const std::string& datum_buffer = datum.data();
+  std::string buffer(crop_datum_size, ' ');
+  for (int h = h_off; h < h_off + height; ++h) {
+    for (int w = w_off; w < w_off + width; ++w) {
+      for (int c = 0; c < datum_channels; ++c) {
+        int datum_index = (c * datum_height + h) * datum_width + w;
+        int crop_datum_index = (c * height + h - h_off) * width + w - w_off;
+        buffer[crop_datum_index] = datum_buffer[datum_index];
+      }
+    }
+  }
+  crop_datum->set_data(buffer);
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::CropImage(const AnnotatedDatum& anno_datum,
+                                       const NormalizedBBox& bbox,
+                                       AnnotatedDatum* cropped_anno_datum) {
+  // Crop the datum.
+  CropImage(anno_datum.datum(), bbox, cropped_anno_datum->mutable_datum());
+  cropped_anno_datum->set_type(anno_datum.type());
+
+  // Transform the annotation according to crop_bbox.
+  bool do_mirror = false;
+  NormalizedBBox crop_bbox;
+  ClipBBox(bbox, &crop_bbox);
+  TransformAnnotation(anno_datum, crop_bbox, do_mirror,
+                      cropped_anno_datum->mutable_annotation_group());
 }
 
 #ifdef USE_OPENCV
@@ -321,43 +427,13 @@ void DataTransformer<Dtype>::Transform(const vector<cv::Mat> & mat_vector,
 
 template<typename Dtype>
 void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
-        Blob<Dtype>* transformed_blob, RandNumbers& rand_num) {
-  const bool do_mirror = param_.mirror() && rand_num(2);
-  const bool has_mean_file = param_.has_mean_file();
-  const bool has_mean_values = mean_values_.size() > 0;
-
-  int transform_func_id = (do_mirror << 2) +
-                          (has_mean_file << 1) +
-                          has_mean_values;
-
-  switch (transform_func_id) {
-    case 0: Transform<false, false, false>(cv_img, transformed_blob, rand_num);
-      break;
-    case 1: Transform<false, false, true >(cv_img, transformed_blob, rand_num);
-      break;
-    case 2: Transform<false, true , false>(cv_img, transformed_blob, rand_num);
-      break;
-    case 3: Transform<false, true , true >(cv_img, transformed_blob, rand_num);
-      break;
-    case 4: Transform<true , false, false>(cv_img, transformed_blob, rand_num);
-      break;
-    case 5: Transform<true , false, true >(cv_img, transformed_blob, rand_num);
-      break;
-    case 6: Transform<true , true , false>(cv_img, transformed_blob, rand_num);
-      break;
-    case 7: Transform<true , true , true >(cv_img, transformed_blob, rand_num);
-      break;
-  }
-}
-
-template<typename Dtype>
-template<bool do_mirror, bool has_mean_file, bool has_mean_values>
-void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
-        Blob<Dtype>* transformed_blob, RandNumbers& rand_num) {
+                                       Blob<Dtype>* transformed_blob,
+                                       NormalizedBBox* crop_bbox,
+                                       bool* do_mirror) {
   const int crop_size = param_.crop_size();
   const int img_channels = cv_img.channels();
-  const int img_height = cv_img.rows;
-  const int img_width = cv_img.cols;
+  int img_height = cv_img.rows;
+  int img_width = cv_img.cols;
 
   // Check dimensions.
   const int channels = transformed_blob->channels();
@@ -366,17 +442,30 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
   const int num = transformed_blob->num();
 
   CHECK_EQ(channels, img_channels);
-  CHECK_LE(height, img_height);
-  CHECK_LE(width, img_width);
   CHECK_GE(num, 1);
 
   CHECK(cv_img.depth() == CV_8U) << "Image data type must be unsigned byte";
 
   const Dtype scale = param_.scale();
+  *do_mirror = param_.mirror() && Rand(2);
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_mean_values = mean_values_.size() > 0;
+  cv::Mat cv_resized_image, cv_noised_image, cv_cropped_image;
 
+  *crop_bbox = UnitBBox();
+  if (param_.has_resize_param()) {
+    cv_resized_image = ApplyResize(cv_img, param_.resize_param());
+    UpdateBBoxByResizePolicy(param_.resize_param(), img_width, img_height,
+                             crop_bbox);
+  } else {
+    cv_resized_image = cv_img;
+  }
+  if (param_.has_noise_param()) {
+    cv_noised_image = ApplyNoise(cv_resized_image, param_.noise_param());
+  } else {
+    cv_noised_image = cv_resized_image;
+  }
   CHECK_GT(img_channels, 0);
-  CHECK_GE(img_height, crop_size);
-  CHECK_GE(img_width, crop_size);
 
   Dtype* mean = NULL;
   if (has_mean_file) {
@@ -387,7 +476,7 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
   }
   if (has_mean_values) {
     CHECK(mean_values_.size() == 1 || mean_values_.size() == img_channels) <<
-     "Specify either 1 mean_value or as many as channels: " << img_channels;
+        "Specify either 1 mean_value or as many as channels: " << img_channels;
     if (img_channels > 1 && mean_values_.size() == 1) {
       // Replicate the mean_value for simplicity
       for (int c = 1; c < img_channels; ++c) {
@@ -396,51 +485,68 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
     }
   }
 
-  int h_off = 0;
-  int w_off = 0;
-  cv::Mat cv_cropped_img = cv_img;
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
   if (crop_size) {
-    CHECK_EQ(crop_size, height);
-    CHECK_EQ(crop_size, width);
-    // We only do random crop when we do training.
-    if (phase_ == TRAIN) {
-      h_off = rand_num(img_height - crop_size + 1);
-      w_off = rand_num(img_width - crop_size + 1);
-    } else {
-      h_off = (img_height - crop_size) / 2;
-      w_off = (img_width - crop_size) / 2;
-    }
-    cv::Rect roi(w_off, h_off, crop_size, crop_size);
-    cv_cropped_img = cv_img(roi);
-  } else {
-    CHECK_EQ(img_height, height);
-    CHECK_EQ(img_width, width);
+    crop_h = crop_size;
+    crop_w = crop_size;
   }
 
-  CHECK(cv_cropped_img.data);
+  img_height = cv_noised_image.rows;
+  img_width = cv_noised_image.cols;
+  CHECK_GE(img_height, crop_h);
+  CHECK_GE(img_width, crop_w);
+
+  int h_off = 0;
+  int w_off = 0;
+  if ((crop_h > 0) && (crop_w > 0)) {
+    CHECK_EQ(crop_h, height);
+    CHECK_EQ(crop_w, width);
+    // We only do random crop when we do training.
+    if (phase_ == TRAIN) {
+      h_off = Rand(img_height - crop_h + 1);
+      w_off = Rand(img_width - crop_w + 1);
+    } else {
+      h_off = (img_height - crop_h) / 2;
+      w_off = (img_width - crop_w) / 2;
+    }
+    cv::Rect roi(w_off, h_off, crop_w, crop_h);
+    cv_cropped_image = cv_noised_image(roi);
+  } else {
+    cv_cropped_image = cv_noised_image;
+  }
+
+  if (has_mean_file) {
+    CHECK_EQ(cv_cropped_image.rows, data_mean_.height());
+    CHECK_EQ(cv_cropped_image.cols, data_mean_.width());
+  }
+  CHECK(cv_cropped_image.data);
 
   Dtype* transformed_data = transformed_blob->mutable_cpu_data();
   int top_index;
   for (int h = 0; h < height; ++h) {
-    const uchar* ptr = cv_cropped_img.ptr<uchar>(h);
+    const uchar* ptr = cv_cropped_image.ptr<uchar>(h);
     int img_index = 0;
+    int h_idx = h;
     for (int w = 0; w < width; ++w) {
+      int w_idx = w;
+      if (*do_mirror) {
+        w_idx = (width - 1 - w);
+      }
+      int h_idx_real = h_idx;
+      int w_idx_real = w_idx;
       for (int c = 0; c < img_channels; ++c) {
-        if (do_mirror) {
-          top_index = (c * height + h) * width + (width - 1 - w);
-        } else {
-          top_index = (c * height + h) * width + w;
-        }
-        // int top_index = (c * height + h) * width + w;
+        top_index = (c * height + h_idx_real) * width + w_idx_real;
         Dtype pixel = static_cast<Dtype>(ptr[img_index++]);
         if (has_mean_file) {
-          int mean_index = (c * img_height + h_off + h) * img_width + w_off + w;
+          int mean_index = (c * img_height + h_off + h_idx_real) * img_width
+              + w_off + w_idx_real;
           transformed_data[top_index] =
-            (pixel - mean[mean_index]) * scale;
+              (pixel - mean[mean_index]) * scale;
         } else {
           if (has_mean_values) {
             transformed_data[top_index] =
-              (pixel - mean_values_[c]) * scale;
+                (pixel - mean_values_[c]) * scale;
           } else {
             transformed_data[top_index] = pixel * scale;
           }
@@ -448,6 +554,110 @@ void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
       }
     }
   }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformInv(const Dtype* data, cv::Mat* cv_img,
+                                          const int height, const int width,
+                                          const int channels) {
+  const Dtype scale = param_.scale();
+  const bool has_mean_file = param_.has_mean_file();
+  const bool has_mean_values = mean_values_.size() > 0;
+
+  Dtype* mean = NULL;
+  if (has_mean_file) {
+    CHECK_EQ(channels, data_mean_.channels());
+    CHECK_EQ(height, data_mean_.height());
+    CHECK_EQ(width, data_mean_.width());
+    mean = data_mean_.mutable_cpu_data();
+  }
+  if (has_mean_values) {
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == channels) <<
+        "Specify either 1 mean_value or as many as channels: " << channels;
+    if (channels > 1 && mean_values_.size() == 1) {
+      // Replicate the mean_value for simplicity
+      for (int c = 1; c < channels; ++c) {
+        mean_values_.push_back(mean_values_[0]);
+      }
+    }
+  }
+
+  const int img_type = channels == 3 ? CV_8UC3 : CV_8UC1;
+  cv::Mat orig_img(height, width, img_type, cv::Scalar(0, 0, 0));
+  for (int h = 0; h < height; ++h) {
+    uchar* ptr = orig_img.ptr<uchar>(h);
+    int img_idx = 0;
+    for (int w = 0; w < width; ++w) {
+      for (int c = 0; c < channels; ++c) {
+        int idx = (c * height + h) * width + w;
+        if (has_mean_file) {
+          ptr[img_idx++] = static_cast<uchar>(data[idx] / scale + mean[idx]);
+        } else {
+          if (has_mean_values) {
+            ptr[img_idx++] =
+                static_cast<uchar>(data[idx] / scale + mean_values_[c]);
+          } else {
+            ptr[img_idx++] = static_cast<uchar>(data[idx] / scale);
+          }
+        }
+      }
+    }
+  }
+
+  if (param_.has_resize_param()) {
+    *cv_img = ApplyResize(orig_img, param_.resize_param());
+  } else {
+    *cv_img = orig_img;
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::TransformInv(const Blob<Dtype>* blob,
+                                          vector<cv::Mat>* cv_imgs) {
+  const int channels = blob->channels();
+  const int height = blob->height();
+  const int width = blob->width();
+  const int num = blob->num();
+  CHECK_GE(num, 1);
+  const Dtype* image_data = blob->cpu_data();
+
+  for (int i = 0; i < num; ++i) {
+    cv::Mat cv_img;
+    TransformInv(image_data, &cv_img, height, width, channels);
+    cv_imgs->push_back(cv_img);
+    image_data += blob->offset(1);
+  }
+}
+
+template<typename Dtype>
+void DataTransformer<Dtype>::Transform(const cv::Mat& cv_img,
+                                       Blob<Dtype>* transformed_blob) {
+  NormalizedBBox crop_bbox;
+  bool do_mirror;
+  Transform(cv_img, transformed_blob, &crop_bbox, &do_mirror);
+}
+
+template <typename Dtype>
+void DataTransformer<Dtype>::CropImage(const cv::Mat& img,
+                                       const NormalizedBBox& bbox,
+                                       cv::Mat* crop_img) {
+  const int img_height = img.rows;
+  const int img_width = img.cols;
+
+  // Get the bbox dimension.
+  NormalizedBBox clipped_bbox;
+  ClipBBox(bbox, &clipped_bbox);
+  NormalizedBBox scaled_bbox;
+  ScaleBBox(clipped_bbox, img_height, img_width, &scaled_bbox);
+
+  // Crop the image using bbox.
+  int w_off = static_cast<int>(scaled_bbox.xmin());
+  int h_off = static_cast<int>(scaled_bbox.ymin());
+  int width = static_cast<int>(scaled_bbox.xmax() - scaled_bbox.xmin());
+  int height = static_cast<int>(scaled_bbox.ymax() - scaled_bbox.ymin());
+  cv::Rect bbox_roi(w_off, h_off, width, height);
+
+  img(bbox_roi).copyTo(*crop_img);
 }
 #endif  // USE_OPENCV
 
@@ -484,7 +694,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
 
 
   const Dtype scale = param_.scale();
-  const bool do_mirror = param_.mirror() && rand_num_(2);
+  const bool do_mirror = param_.mirror() && Rand(2);
   const bool has_mean_file = param_.has_mean_file();
   const bool has_mean_values = mean_values_.size() > 0;
 
@@ -495,8 +705,8 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
     CHECK_EQ(crop_size, width);
     // We only do random crop when we do training.
     if (phase_ == TRAIN) {
-      h_off = rand_num_(input_height - crop_size + 1);
-      w_off = rand_num_(input_width - crop_size + 1);
+      h_off = Rand(input_height - crop_size + 1);
+      w_off = Rand(input_width - crop_size + 1);
     } else {
       h_off = (input_height - crop_size) / 2;
       w_off = (input_width - crop_size) / 2;
@@ -514,13 +724,14 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
     for (int n = 0; n < input_num; ++n) {
       int offset = input_blob->offset(n);
       caffe_sub(data_mean_.count(), input_data + offset,
-            data_mean_.cpu_data(), input_data + offset);
+                data_mean_.cpu_data(), input_data + offset);
     }
   }
 
   if (has_mean_values) {
-    CHECK(mean_values_.size() == 1 || mean_values_.size() == input_channels) <<
-     "Specify either 1 mean_value or as many as channels: " << input_channels;
+    CHECK(mean_values_.size() == 1 || mean_values_.size() == input_channels)
+        << "Specify either 1 mean_value or as many as channels: "
+        << input_channels;
     if (mean_values_.size() == 1) {
       caffe_add_scalar(input_blob->count(), -(mean_values_[0]), input_data);
     } else {
@@ -528,7 +739,7 @@ void DataTransformer<Dtype>::Transform(Blob<Dtype>* input_blob,
         for (int c = 0; c < input_channels; ++c) {
           int offset = input_blob->offset(n, c);
           caffe_add_scalar(input_height * input_width, -(mean_values_[c]),
-            input_data + offset);
+                           input_data + offset);
         }
       }
     }
@@ -583,20 +794,39 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(const Datum& datum) {
     LOG(FATAL) << "Encoded datum requires OpenCV; compile with USE_OPENCV.";
 #endif  // USE_OPENCV
   }
+
   const int crop_size = param_.crop_size();
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
   const int datum_channels = datum.channels();
-  const int datum_height = datum.height();
-  const int datum_width = datum.width();
+  int datum_height = datum.height();
+  int datum_width = datum.width();
+
   // Check dimensions.
   CHECK_GT(datum_channels, 0);
-  CHECK_GE(datum_height, crop_size);
-  CHECK_GE(datum_width, crop_size);
+  if (param_.has_resize_param()) {
+    if (param_.resize_param().has_height() &&
+        param_.resize_param().height() > 0) {
+      datum_height = param_.resize_param().height();
+    }
+    if (param_.resize_param().has_width() &&
+        param_.resize_param().width() > 0) {
+      datum_width = param_.resize_param().width();
+    }
+  }
+  CHECK_GE(datum_height, crop_h);
+  CHECK_GE(datum_width, crop_w);
+
   // Build BlobShape.
   vector<int> shape(4);
   shape[0] = 1;
   shape[1] = datum_channels;
-  shape[2] = (crop_size)? crop_size: datum_height;
-  shape[3] = (crop_size)? crop_size: datum_width;
+  shape[2] = (crop_h)? crop_h: datum_height;
+  shape[3] = (crop_w)? crop_w: datum_width;
   return shape;
 }
 
@@ -616,19 +846,36 @@ vector<int> DataTransformer<Dtype>::InferBlobShape(
 template<typename Dtype>
 vector<int> DataTransformer<Dtype>::InferBlobShape(const cv::Mat& cv_img) {
   const int crop_size = param_.crop_size();
+  int crop_h = param_.crop_h();
+  int crop_w = param_.crop_w();
+  if (crop_size) {
+    crop_h = crop_size;
+    crop_w = crop_size;
+  }
   const int img_channels = cv_img.channels();
-  const int img_height = cv_img.rows;
-  const int img_width = cv_img.cols;
+  int img_height = cv_img.rows;
+  int img_width = cv_img.cols;
   // Check dimensions.
   CHECK_GT(img_channels, 0);
-  CHECK_GE(img_height, crop_size);
-  CHECK_GE(img_width, crop_size);
+  if (param_.has_resize_param()) {
+    if (param_.resize_param().has_height() &&
+        param_.resize_param().height() > 0) {
+      img_height = param_.resize_param().height();
+    }
+    if (param_.resize_param().has_width() &&
+        param_.resize_param().width() > 0) {
+      img_width = param_.resize_param().width();
+    }
+  }
+  CHECK_GE(img_height, crop_h);
+  CHECK_GE(img_width, crop_w);
+
   // Build BlobShape.
   vector<int> shape(4);
   shape[0] = 1;
   shape[1] = img_channels;
-  shape[2] = (crop_size)? crop_size: img_height;
-  shape[3] = (crop_size)? crop_size: img_width;
+  shape[2] = (crop_h)? crop_h: img_height;
+  shape[3] = (crop_w)? crop_w: img_width;
   return shape;
 }
 
@@ -650,10 +897,20 @@ void DataTransformer<Dtype>::InitRand() {
   const bool needs_rand = param_.mirror() ||
       (phase_ == TRAIN && param_.crop_size());
   if (needs_rand) {
-    rand_num_.Init();
+    const unsigned int rng_seed = caffe_rng_rand();
+    rng_.reset(new Caffe::RNG(rng_seed));
   } else {
-    rand_num_.Reset();
+    rng_.reset();
   }
+}
+
+template <typename Dtype>
+int DataTransformer<Dtype>::Rand(int n) {
+  CHECK(rng_);
+  CHECK_GT(n, 0);
+  caffe::rng_t* rng =
+      static_cast<caffe::rng_t*>(rng_->generator());
+  return ((*rng)() % n);
 }
 
 INSTANTIATE_CLASS(DataTransformer);

--- a/src/caffe/layers/annotated_data_layer.cpp
+++ b/src/caffe/layers/annotated_data_layer.cpp
@@ -1,0 +1,240 @@
+#ifdef USE_OPENCV
+#include <opencv2/core/core.hpp>
+#endif  // USE_OPENCV
+#include <stdint.h>
+
+#include <algorithm>
+#include <map>
+#include <vector>
+
+#include "caffe/data_transformer.hpp"
+#include "caffe/layers/annotated_data_layer.hpp"
+#include "caffe/util/benchmark.hpp"
+#include "caffe/util/sampler.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+AnnotatedDataLayer<Dtype>::AnnotatedDataLayer(const LayerParameter& param)
+  : BasePrefetchingDataLayer<Dtype>(param),
+    reader_(param) {
+}
+
+template <typename Dtype>
+AnnotatedDataLayer<Dtype>::~AnnotatedDataLayer() {
+  this->StopInternalThread();
+}
+
+template <typename Dtype>
+void AnnotatedDataLayer<Dtype>::DataLayerSetUp(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  const AnnotatedDataParameter& anno_data_param =
+      this->layer_param_.annotated_data_param();
+  for (int i = 0; i < anno_data_param.batch_sampler_size(); ++i) {
+    batch_samplers_.push_back(anno_data_param.batch_sampler(i));
+  }
+  label_map_file_ = anno_data_param.label_map_file();
+
+  // Read a data point, and use it to initialize the top blob.
+  AnnotatedDatum& anno_datum = *(reader_.full().peek());
+
+  // Use data_transformer to infer the expected blob shape from anno_datum.
+  vector<int> top_shape =
+      this->data_transformer_->InferBlobShape(anno_datum.datum());
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape top[0] and prefetch_data according to the batch_size.
+  top_shape[0] = batch_size;
+  top[0]->Reshape(top_shape);
+  for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+    this->prefetch_[i].data_.Reshape(top_shape);
+  }
+  LOG(INFO) << "output data size: " << top[0]->num() << ","
+      << top[0]->channels() << "," << top[0]->height() << ","
+      << top[0]->width();
+  // label
+  if (this->output_labels_) {
+    has_anno_type_ = anno_datum.has_type();
+    vector<int> label_shape(4, 1);
+    if (has_anno_type_) {
+      anno_type_ = anno_datum.type();
+      // Infer the label shape from anno_datum.AnnotationGroup().
+      int num_bboxes = 0;
+      if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+        // Since the number of bboxes can be different for each image,
+        // we store the bbox information in a specific format. In specific:
+        // All bboxes are stored in one spatial plane (num and channels are 1)
+        // And each row contains one and only one box in the following format:
+        // [item_id, group_label, instance_id, xmin, ymin, xmax, ymax, diff]
+        // Note: Refer to caffe.proto for details about group_label and
+        // instance_id.
+        for (int g = 0; g < anno_datum.annotation_group_size(); ++g) {
+          num_bboxes += anno_datum.annotation_group(g).annotation_size();
+        }
+        label_shape[0] = 1;
+        label_shape[1] = 1;
+        // BasePrefetchingDataLayer<Dtype>::LayerSetUp() requires to call
+        // cpu_data and gpu_data for consistent prefetch thread. Thus we make
+        // sure there is at least one bbox.
+        label_shape[2] = std::max(num_bboxes, 1);
+        label_shape[3] = 8;
+      } else {
+        LOG(FATAL) << "Unknown annotation type.";
+      }
+    } else {
+      label_shape[0] = batch_size;
+    }
+    top[1]->Reshape(label_shape);
+    for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
+      this->prefetch_[i].label_.Reshape(label_shape);
+    }
+  }
+}
+
+// This function is called on prefetch thread
+template<typename Dtype>
+void AnnotatedDataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
+  CPUTimer batch_timer;
+  batch_timer.Start();
+  double read_time = 0;
+  double trans_time = 0;
+  CPUTimer timer;
+  CHECK(batch->data_.count());
+  CHECK(this->transformed_data_.count());
+
+  // Reshape according to the first anno_datum of each batch
+  // on single input batches allows for inputs of varying dimension.
+  const int batch_size = this->layer_param_.data_param().batch_size();
+  AnnotatedDatum& anno_datum = *(reader_.full().peek());
+  // Use data_transformer to infer the expected blob shape from anno_datum.
+  vector<int> top_shape =
+      this->data_transformer_->InferBlobShape(anno_datum.datum());
+  this->transformed_data_.Reshape(top_shape);
+  // Reshape batch according to the batch_size.
+  top_shape[0] = batch_size;
+  batch->data_.Reshape(top_shape);
+
+  Dtype* top_data = batch->data_.mutable_cpu_data();
+  Dtype* top_label = NULL;  // suppress warnings about uninitialized variables
+  if (this->output_labels_ && !has_anno_type_) {
+    top_label = batch->label_.mutable_cpu_data();
+  }
+
+  // Store transformed annotation.
+  map<int, vector<AnnotationGroup> > all_anno;
+  int num_bboxes = 0;
+
+  for (int item_id = 0; item_id < batch_size; ++item_id) {
+    timer.Start();
+    // get a anno_datum
+    AnnotatedDatum& anno_datum = *(reader_.full().pop("Waiting for data"));
+    read_time += timer.MicroSeconds();
+    timer.Start();
+    AnnotatedDatum sampled_datum;
+    if (batch_samplers_.size() > 0) {
+      // Generate sampled bboxes from anno_datum.
+      vector<NormalizedBBox> sampled_bboxes;
+      GenerateBatchSamples(anno_datum, batch_samplers_, &sampled_bboxes);
+      if (sampled_bboxes.size() > 0) {
+        // Randomly pick a sampled bbox and crop the anno_datum.
+        int rand_idx = caffe_rng_rand() % sampled_bboxes.size();
+        this->data_transformer_->CropImage(anno_datum, sampled_bboxes[rand_idx],
+                                           &sampled_datum);
+      } else {
+        sampled_datum.CopyFrom(anno_datum);
+      }
+    } else {
+      sampled_datum.CopyFrom(anno_datum);
+    }
+    // Apply data transformations (mirror, scale, crop...)
+    int offset = batch->data_.offset(item_id);
+    this->transformed_data_.set_cpu_data(top_data + offset);
+    vector<AnnotationGroup> transformed_anno_vec;
+    if (this->output_labels_) {
+      if (has_anno_type_) {
+        // Make sure all data have same annotation type.
+        CHECK(sampled_datum.has_type()) << "Some datum misses AnnotationType.";
+        CHECK_EQ(anno_type_, sampled_datum.type()) <<
+            "Different AnnotationType.";
+        // Transform datum and annotation_group at the same time
+        transformed_anno_vec.clear();
+        this->data_transformer_->Transform(sampled_datum,
+                                           &(this->transformed_data_),
+                                           &transformed_anno_vec);
+        if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+          // Count the number of bboxes.
+          for (int g = 0; g < transformed_anno_vec.size(); ++g) {
+            num_bboxes += transformed_anno_vec[g].annotation_size();
+          }
+        } else {
+          LOG(FATAL) << "Unknown annotation type.";
+        }
+        all_anno[item_id] = transformed_anno_vec;
+      } else {
+        this->data_transformer_->Transform(sampled_datum.datum(),
+                                           &(this->transformed_data_));
+        // Otherwise, store the label from datum.
+        CHECK(sampled_datum.datum().has_label()) << "Cannot find any label.";
+        top_label[item_id] = sampled_datum.datum().label();
+      }
+    } else {
+      this->data_transformer_->Transform(sampled_datum.datum(),
+                                         &(this->transformed_data_));
+    }
+    trans_time += timer.MicroSeconds();
+
+    reader_.free().push(const_cast<AnnotatedDatum*>(&anno_datum));
+  }
+
+  // Store "rich" annotation if needed.
+  if (this->output_labels_ && has_anno_type_) {
+    vector<int> label_shape(4);
+    if (anno_type_ == AnnotatedDatum_AnnotationType_BBOX) {
+      label_shape[0] = 1;
+      label_shape[1] = 1;
+      label_shape[3] = 8;
+      if (num_bboxes == 0) {
+        // Store all -1 in the label.
+        label_shape[2] = 1;
+        batch->label_.Reshape(label_shape);
+        caffe_set<Dtype>(8, -1, batch->label_.mutable_cpu_data());
+      } else {
+        // Reshape the label and store the annotation.
+        label_shape[2] = num_bboxes;
+        batch->label_.Reshape(label_shape);
+        top_label = batch->label_.mutable_cpu_data();
+        int idx = 0;
+        for (int item_id = 0; item_id < batch_size; ++item_id) {
+          const vector<AnnotationGroup>& anno_vec = all_anno[item_id];
+          for (int g = 0; g < anno_vec.size(); ++g) {
+            const AnnotationGroup& anno_group = anno_vec[g];
+            for (int a = 0; a < anno_group.annotation_size(); ++a) {
+              const Annotation& anno = anno_group.annotation(a);
+              const NormalizedBBox& bbox = anno.bbox();
+              top_label[idx++] = item_id;
+              top_label[idx++] = anno_group.group_label();
+              top_label[idx++] = anno.instance_id();
+              top_label[idx++] = bbox.xmin();
+              top_label[idx++] = bbox.ymin();
+              top_label[idx++] = bbox.xmax();
+              top_label[idx++] = bbox.ymax();
+              top_label[idx++] = bbox.difficult();
+            }
+          }
+        }
+      }
+    } else {
+      LOG(FATAL) << "Unknown annotation type.";
+    }
+  }
+  timer.Stop();
+  batch_timer.Stop();
+  DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
+  DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
+  DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";
+}
+
+INSTANTIATE_CLASS(AnnotatedDataLayer);
+REGISTER_LAYER_CLASS(AnnotatedData);
+
+}  // namespace caffe

--- a/src/caffe/layers/data_layer.cpp
+++ b/src/caffe/layers/data_layer.cpp
@@ -1,45 +1,8 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #ifdef USE_OPENCV
 #include <opencv2/core/core.hpp>
 #endif  // USE_OPENCV
 #include <stdint.h>
-#include <string>
+
 #include <vector>
 
 #include "caffe/data_transformer.hpp"
@@ -64,15 +27,13 @@ void DataLayer<Dtype>::DataLayerSetUp(const vector<Blob<Dtype>*>& bottom,
       const vector<Blob<Dtype>*>& top) {
   const int batch_size = this->layer_param_.data_param().batch_size();
   // Read a data point, and use it to initialize the top blob.
-  Datum datum;
-  datum.ParseFromString(*(reader_.full().peek()));
+  Datum& datum = *(reader_.full().peek());
 
   // Use data_transformer to infer the expected blob shape from datum.
   vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
   this->transformed_data_.Reshape(top_shape);
   // Reshape top[0] and prefetch_data according to the batch_size.
   top_shape[0] = batch_size;
-
   top[0]->Reshape(top_shape);
   for (int i = 0; i < this->PREFETCH_COUNT; ++i) {
     this->prefetch_[i].data_.Reshape(top_shape);
@@ -98,23 +59,16 @@ void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   double read_time = 0;
   double trans_time = 0;
   CPUTimer timer;
-  CPUTimer trans_timer;
   CHECK(batch->data_.count());
-
-#ifndef _OPENMP
   CHECK(this->transformed_data_.count());
-#endif
 
   // Reshape according to the first datum of each batch
   // on single input batches allows for inputs of varying dimension.
   const int batch_size = this->layer_param_.data_param().batch_size();
-  Datum datum;
-  datum.ParseFromString(*(reader_.full().peek()));
+  Datum& datum = *(reader_.full().peek());
   // Use data_transformer to infer the expected blob shape from datum.
   vector<int> top_shape = this->data_transformer_->InferBlobShape(datum);
-#ifndef _OPENMP
   this->transformed_data_.Reshape(top_shape);
-#endif
   // Reshape batch according to the batch_size.
   top_shape[0] = batch_size;
   batch->data_.Reshape(top_shape);
@@ -125,52 +79,26 @@ void DataLayer<Dtype>::load_batch(Batch<Dtype>* batch) {
   if (this->output_labels_) {
     top_label = batch->label_.mutable_cpu_data();
   }
-
-  trans_timer.Start();
-#ifdef _OPENMP
-  #pragma omp parallel if (batch_size > 1)
-  #pragma omp single nowait
-#endif
   for (int item_id = 0; item_id < batch_size; ++item_id) {
     timer.Start();
     // get a datum
-    string* data = (reader_.full().pop("Waiting for data"));
-    timer.Stop();
+    Datum& datum = *(reader_.full().pop("Waiting for data"));
     read_time += timer.MicroSeconds();
+    timer.Start();
     // Apply data transformations (mirror, scale, crop...)
     int offset = batch->data_.offset(item_id);
-
-#ifdef _OPENMP
-    PreclcRandomNumbers precalculated_rand_numbers;
-    this->data_transformer_->GenerateRandNumbers(precalculated_rand_numbers);
-    #pragma omp task firstprivate(offset, precalculated_rand_numbers, data, item_id)
-#endif
-    {
-      Datum datum;
-      datum.ParseFromString(*data);
-      (reader_.free()).push(data);  
-      // Copy label. We need to copy it before we release datum
-      if (this->output_labels_) {
-        top_label[item_id] = datum.label();
-      }
-#ifdef _OPENMP
-      Blob<Dtype> tmp_data;
-      tmp_data.Reshape(top_shape);
-      tmp_data.set_cpu_data(top_data + offset);
-      this->data_transformer_->Transform(datum, &tmp_data,
-                                              precalculated_rand_numbers);
-#else
-      this->transformed_data_.set_cpu_data(top_data + offset);
-      this->data_transformer_->Transform(datum, &(this->transformed_data_));
-#endif
+    this->transformed_data_.set_cpu_data(top_data + offset);
+    this->data_transformer_->Transform(datum, &(this->transformed_data_));
+    // Copy label.
+    if (this->output_labels_) {
+      top_label[item_id] = datum.label();
     }
+    trans_time += timer.MicroSeconds();
+
+    reader_.free().push(const_cast<Datum*>(&datum));
   }
-  trans_timer.Stop();
+  timer.Stop();
   batch_timer.Stop();
-  // Due to multithreaded nature of transformation,
-  // time it takes to execute them we get from subtracting
-  // read batch of images time from total batch read&transform time
-  trans_time = trans_timer.MicroSeconds() - read_time;
   DLOG(INFO) << "Prefetch batch: " << batch_timer.MilliSeconds() << " ms.";
   DLOG(INFO) << "     Read time: " << read_time / 1000 << " ms.";
   DLOG(INFO) << "Transform time: " << trans_time / 1000 << " ms.";

--- a/src/caffe/layers/detection_evaluate_layer.cpp
+++ b/src/caffe/layers/detection_evaluate_layer.cpp
@@ -1,0 +1,230 @@
+#include <algorithm>
+#include <map>
+#include <string>
+#include <vector>
+
+#include "caffe/layers/detection_evaluate_layer.hpp"
+#include "caffe/util/bbox_util.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DetectionEvaluateLayer<Dtype>::LayerSetUp(
+      const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  const DetectionEvaluateParameter& detection_evaluate_param =
+      this->layer_param_.detection_evaluate_param();
+  CHECK(detection_evaluate_param.has_num_classes())
+      << "Must provide num_classes.";
+  num_classes_ = detection_evaluate_param.num_classes();
+  background_label_id_ = detection_evaluate_param.background_label_id();
+  overlap_threshold_ = detection_evaluate_param.overlap_threshold();
+  CHECK_GT(overlap_threshold_, 0.) << "overlap_threshold must be non negative.";
+  evaluate_difficult_gt_ = detection_evaluate_param.evaluate_difficult_gt();
+  if (detection_evaluate_param.has_name_size_file()) {
+    string name_size_file = detection_evaluate_param.name_size_file();
+    std::ifstream infile(name_size_file.c_str());
+    CHECK(infile.good())
+        << "Failed to open name size file: " << name_size_file;
+    // The file is in the following format:
+    //    name height width
+    //    ...
+    string name;
+    int height, width;
+    while (infile >> name >> height >> width) {
+      sizes_.push_back(std::make_pair(height, width));
+    }
+    infile.close();
+  }
+  count_ = 0;
+  // If there is no name_size_file provided, use normalized bbox to evaluate.
+  use_normalized_bbox_ = sizes_.size() == 0;
+}
+
+template <typename Dtype>
+void DetectionEvaluateLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  CHECK_LE(count_, sizes_.size());
+  CHECK_EQ(bottom[0]->num(), 1);
+  CHECK_EQ(bottom[0]->channels(), 1);
+  CHECK_EQ(bottom[0]->width(), 7);
+  CHECK_EQ(bottom[1]->num(), 1);
+  CHECK_EQ(bottom[1]->channels(), 1);
+  CHECK_EQ(bottom[1]->width(), 8);
+
+  // num() and channels() are 1.
+  vector<int> top_shape(2, 1);
+  int num_pos_classes = background_label_id_ == -1 ?
+      num_classes_ : num_classes_ - 1;
+  top_shape.push_back(num_pos_classes + bottom[0]->height());
+  // Each row is a 5 dimension vector, which stores
+  // [image_id, label, confidence, true_pos, false_pos]
+  top_shape.push_back(5);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Dtype>
+void DetectionEvaluateLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  const Dtype* det_data = bottom[0]->cpu_data();
+  const Dtype* gt_data = bottom[1]->cpu_data();
+
+  // Retrieve all detection results.
+  map<int, LabelBBox> all_detections;
+  GetDetectionResults(det_data, bottom[0]->height(), background_label_id_,
+                      &all_detections);
+
+  // Retrieve all ground truth (including difficult ones).
+  map<int, LabelBBox> all_gt_bboxes;
+  GetGroundTruth(gt_data, bottom[1]->height(), background_label_id_,
+                 true, &all_gt_bboxes);
+
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  caffe_set(top[0]->count(), Dtype(0.), top_data);
+  int num_det = 0;
+
+  // Insert number of ground truth for each label.
+  map<int, int> num_pos;
+  for (map<int, LabelBBox>::iterator it = all_gt_bboxes.begin();
+       it != all_gt_bboxes.end(); ++it) {
+    for (LabelBBox::iterator iit = it->second.begin(); iit != it->second.end();
+         ++iit) {
+      int count = 0;
+      if (evaluate_difficult_gt_) {
+        count = iit->second.size();
+      } else {
+        // Get number of non difficult ground truth.
+        for (int i = 0; i < iit->second.size(); ++i) {
+          if (!iit->second[i].difficult()) {
+            ++count;
+          }
+        }
+      }
+      if (num_pos.find(iit->first) == num_pos.end()) {
+        num_pos[iit->first] = count;
+      } else {
+        num_pos[iit->first] += count;
+      }
+    }
+  }
+  for (int c = 0; c < num_classes_; ++c) {
+    if (c == background_label_id_) {
+      continue;
+    }
+    top_data[num_det * 5] = -1;
+    top_data[num_det * 5 + 1] = c;
+    if (num_pos.find(c) == num_pos.end()) {
+      top_data[num_det * 5 + 2] = 0;
+    } else {
+      top_data[num_det * 5 + 2] = num_pos.find(c)->second;
+    }
+    top_data[num_det * 5 + 3] = -1;
+    top_data[num_det * 5 + 4] = -1;
+    ++num_det;
+  }
+
+  // Insert detection evaluate status.
+  for (map<int, LabelBBox>::iterator it = all_detections.begin();
+       it != all_detections.end(); ++it) {
+    int image_id = it->first;
+    LabelBBox& detections = it->second;
+    if (all_gt_bboxes.find(image_id) == all_gt_bboxes.end()) {
+      // No ground truth for current image. All detections become false_pos.
+      for (LabelBBox::iterator iit = detections.begin();
+           iit != detections.end(); ++iit) {
+        int label = iit->first;
+        const vector<NormalizedBBox>& bboxes = iit->second;
+        for (int i = 0; i < bboxes.size(); ++i) {
+          top_data[num_det * 5] = image_id;
+          top_data[num_det * 5 + 1] = label;
+          top_data[num_det * 5 + 2] = bboxes[i].score();
+          top_data[num_det * 5 + 3] = 0;
+          top_data[num_det * 5 + 4] = 1;
+          ++num_det;
+        }
+      }
+    } else {
+      LabelBBox& label_bboxes = all_gt_bboxes.find(image_id)->second;
+      for (LabelBBox::iterator iit = detections.begin();
+           iit != detections.end(); ++iit) {
+        int label = iit->first;
+        vector<NormalizedBBox>& bboxes = iit->second;
+        if (label_bboxes.find(label) == label_bboxes.end()) {
+          // No ground truth for current label. All detections become false_pos.
+          for (int i = 0; i < bboxes.size(); ++i) {
+            top_data[num_det * 5] = image_id;
+            top_data[num_det * 5 + 1] = label;
+            top_data[num_det * 5 + 2] = bboxes[i].score();
+            top_data[num_det * 5 + 3] = 0;
+            top_data[num_det * 5 + 4] = 1;
+            ++num_det;
+          }
+        } else {
+          vector<NormalizedBBox>& gt_bboxes = label_bboxes.find(label)->second;
+          // Scale ground truth if needed.
+          if (!use_normalized_bbox_) {
+            CHECK_LT(count_, sizes_.size());
+            for (int i = 0; i < gt_bboxes.size(); ++i) {
+              ScaleBBox(gt_bboxes[i], sizes_[count_].first,
+                        sizes_[count_].second, &(gt_bboxes[i]));
+            }
+          }
+          vector<bool> visited(gt_bboxes.size(), false);
+          // Sort detections in descend order based on scores.
+          std::sort(bboxes.begin(), bboxes.end(), SortBBoxDescend);
+          for (int i = 0; i < bboxes.size(); ++i) {
+            top_data[num_det * 5] = image_id;
+            top_data[num_det * 5 + 1] = label;
+            top_data[num_det * 5 + 2] = bboxes[i].score();
+            if (!use_normalized_bbox_) {
+              ScaleBBox(bboxes[i], sizes_[count_].first, sizes_[count_].second,
+                        &(bboxes[i]));
+            }
+            // Compare with each ground truth bbox.
+            float overlap_max = -1;
+            int jmax = -1;
+            for (int j = 0; j < gt_bboxes.size(); ++j) {
+              float overlap = JaccardOverlap(bboxes[i], gt_bboxes[j],
+                                             use_normalized_bbox_);
+              if (overlap > overlap_max) {
+                overlap_max = overlap;
+                jmax = j;
+              }
+            }
+            if (overlap_max >= overlap_threshold_) {
+              if (evaluate_difficult_gt_ ||
+                  (!evaluate_difficult_gt_ && !gt_bboxes[jmax].difficult())) {
+                if (!visited[jmax]) {
+                  // true positive.
+                  top_data[num_det * 5 + 3] = 1;
+                  top_data[num_det * 5 + 4] = 0;
+                  visited[jmax] = true;
+                } else {
+                  // false positive (multiple detection).
+                  top_data[num_det * 5 + 3] = 0;
+                  top_data[num_det * 5 + 4] = 1;
+                }
+              }
+            } else {
+              // false positive.
+              top_data[num_det * 5 + 3] = 0;
+              top_data[num_det * 5 + 4] = 1;
+            }
+            ++num_det;
+          }
+        }
+      }
+    }
+    if (sizes_.size() > 0) {
+      ++count_;
+      if (count_ == sizes_.size()) {
+        // reset count after a full iterations through the DB.
+        count_ = 0;
+      }
+    }
+  }
+}
+
+INSTANTIATE_CLASS(DetectionEvaluateLayer);
+REGISTER_LAYER_CLASS(DetectionEvaluate);
+
+}  // namespace caffe

--- a/src/caffe/layers/detection_output_layer.cpp
+++ b/src/caffe/layers/detection_output_layer.cpp
@@ -1,0 +1,442 @@
+#include <algorithm>
+#include <fstream>  // NOLINT(readability/streams)
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/filesystem.hpp"
+#include "boost/foreach.hpp"
+
+#include "caffe/layers/detection_output_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void DetectionOutputLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const DetectionOutputParameter& detection_output_param =
+      this->layer_param_.detection_output_param();
+  CHECK(detection_output_param.has_num_classes()) << "Must specify num_classes";
+  num_classes_ = detection_output_param.num_classes();
+  share_location_ = detection_output_param.share_location();
+  num_loc_classes_ = share_location_ ? 1 : num_classes_;
+  background_label_id_ = detection_output_param.background_label_id();
+  code_type_ = detection_output_param.code_type();
+  variance_encoded_in_target_ =
+      detection_output_param.variance_encoded_in_target();
+  keep_top_k_ = detection_output_param.keep_top_k();
+  confidence_threshold_ = detection_output_param.has_confidence_threshold() ?
+      detection_output_param.confidence_threshold() : -FLT_MAX;
+  // Parameters used in nms.
+  nms_threshold_ = detection_output_param.nms_param().nms_threshold();
+  CHECK_GE(nms_threshold_, 0.) << "nms_threshold must be non negative.";
+  top_k_ = -1;
+  if (detection_output_param.nms_param().has_top_k()) {
+    top_k_ = detection_output_param.nms_param().top_k();
+  }
+  const SaveOutputParameter& save_output_param =
+      detection_output_param.save_output_param();
+  output_directory_ = save_output_param.output_directory();
+  if (!output_directory_.empty() &&
+      !boost::filesystem::is_directory(output_directory_)) {
+    if (!boost::filesystem::create_directories(output_directory_)) {
+        LOG(FATAL) << "Failed to create directory: " << output_directory_;
+    }
+  }
+  output_name_prefix_ = save_output_param.output_name_prefix();
+  need_save_ = output_directory_ == "" ? false : true;
+  output_format_ = save_output_param.output_format();
+  if (save_output_param.has_label_map_file()) {
+    string label_map_file = save_output_param.label_map_file();
+    if (label_map_file.empty()) {
+      // Ignore saving if there is no label_map_file provided.
+      LOG(WARNING) << "Provide label_map_file if output results to files.";
+      need_save_ = false;
+    } else {
+      LabelMap label_map;
+      CHECK(ReadProtoFromTextFile(label_map_file, &label_map))
+          << "Failed to read label map file: " << label_map_file;
+      CHECK(MapLabelToName(label_map, true, &label_to_name_))
+          << "Failed to convert label to name.";
+      CHECK(MapLabelToDisplayName(label_map, true, &label_to_display_name_))
+          << "Failed to convert label to display name.";
+    }
+  } else {
+    need_save_ = false;
+  }
+  if (save_output_param.has_name_size_file()) {
+    string name_size_file = save_output_param.name_size_file();
+    if (name_size_file.empty()) {
+      // Ignore saving if there is no name_size_file provided.
+      LOG(WARNING) << "Provide name_size_file if output results to files.";
+      need_save_ = false;
+    } else {
+      std::ifstream infile(name_size_file.c_str());
+      CHECK(infile.good())
+          << "Failed to open name size file: " << name_size_file;
+      // The file is in the following format:
+      //    name height width
+      //    ...
+      string name;
+      int height, width;
+      while (infile >> name >> height >> width) {
+        names_.push_back(name);
+        sizes_.push_back(std::make_pair(height, width));
+      }
+      infile.close();
+      if (save_output_param.has_num_test_image()) {
+        num_test_image_ = save_output_param.num_test_image();
+      } else {
+        num_test_image_ = names_.size();
+      }
+      CHECK_LE(num_test_image_, names_.size());
+    }
+  } else {
+    need_save_ = false;
+  }
+  name_count_ = 0;
+  visualize_ = detection_output_param.visualize();
+  if (visualize_) {
+    visualize_threshold_ = 0.6;
+    if (detection_output_param.has_visualize_threshold()) {
+      visualize_threshold_ = detection_output_param.visualize_threshold();
+    }
+    data_transformer_.reset(
+        new DataTransformer<Dtype>(this->layer_param_.transform_param(),
+                                   this->phase_));
+    data_transformer_->InitRand();
+  }
+}
+
+template <typename Dtype>
+void DetectionOutputLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  if (need_save_) {
+    CHECK_LE(name_count_, names_.size());
+    if (name_count_ % num_test_image_ == 0) {
+      // Clean all outputs.
+      if (output_format_ == "VOC") {
+        boost::filesystem::path output_directory(output_directory_);
+        for (map<int, string>::iterator it = label_to_name_.begin();
+             it != label_to_name_.end(); ++it) {
+          if (it->first == background_label_id_) {
+            continue;
+          }
+          std::ofstream outfile;
+          boost::filesystem::path file(
+              output_name_prefix_ + it->second + ".txt");
+          boost::filesystem::path out_file = output_directory / file;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+        }
+      }
+    }
+  }
+  CHECK_EQ(bottom[0]->num(), bottom[1]->num());
+  num_priors_ = bottom[2]->height() / 4;
+  CHECK_EQ(num_priors_ * num_loc_classes_ * 4, bottom[0]->channels())
+      << "Number of priors must match number of location predictions.";
+  CHECK_EQ(num_priors_ * num_classes_, bottom[1]->channels())
+      << "Number of priors must match number of confidence predictions.";
+  // num() and channels() are 1.
+  vector<int> top_shape(2, 1);
+  // Since the number of bboxes to be kept is unknown before nms, we manually
+  // set it to (fake) 1.
+  top_shape.push_back(1);
+  // Each row is a 7 dimension vector, which stores
+  // [image_id, label, confidence, xmin, ymin, xmax, ymax]
+  top_shape.push_back(7);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Dtype>
+void DetectionOutputLayer<Dtype>::Forward_cpu(
+    const vector<Blob<Dtype>*>& bottom, const vector<Blob<Dtype>*>& top) {
+  const Dtype* loc_data = bottom[0]->cpu_data();
+  const Dtype* conf_data = bottom[1]->cpu_data();
+  const Dtype* prior_data = bottom[2]->cpu_data();
+  const int num = bottom[0]->num();
+
+  // Retrieve all location predictions.
+  vector<LabelBBox> all_loc_preds;
+  GetLocPredictions(loc_data, num, num_priors_, num_loc_classes_,
+                    share_location_, &all_loc_preds);
+
+  // Retrieve all confidences.
+  vector<map<int, vector<float> > > all_conf_scores;
+  GetConfidenceScores(conf_data, num, num_priors_, num_classes_,
+                      &all_conf_scores);
+
+  // Retrieve all prior bboxes. It is same within a batch since we assume all
+  // images in a batch are of same dimension.
+  vector<NormalizedBBox> prior_bboxes;
+  vector<vector<float> > prior_variances;
+  GetPriorBBoxes(prior_data, num_priors_, &prior_bboxes, &prior_variances);
+
+  // Decode all loc predictions to bboxes.
+  vector<LabelBBox> all_decode_bboxes;
+  DecodeBBoxesAll(all_loc_preds, prior_bboxes, prior_variances, num,
+                  share_location_, num_loc_classes_, background_label_id_,
+                  code_type_, variance_encoded_in_target_, &all_decode_bboxes);
+
+  int num_kept = 0;
+  vector<map<int, vector<int> > > all_indices;
+  for (int i = 0; i < num; ++i) {
+    const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+    const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+    map<int, vector<int> > indices;
+    int num_det = 0;
+    for (int c = 0; c < num_classes_; ++c) {
+      if (c == background_label_id_) {
+        // Ignore background class.
+        continue;
+      }
+      if (conf_scores.find(c) == conf_scores.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find confidence predictions for label " << c;
+      }
+      const vector<float>& scores = conf_scores.find(c)->second;
+      int label = share_location_ ? -1 : c;
+      if (decode_bboxes.find(label) == decode_bboxes.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for label " << label;
+        continue;
+      }
+      const vector<NormalizedBBox>& bboxes = decode_bboxes.find(label)->second;
+      ApplyNMSFast(bboxes, scores, confidence_threshold_, nms_threshold_,
+          top_k_, &(indices[c]));
+      num_det += indices[c].size();
+    }
+    if (keep_top_k_ > -1 && num_det > keep_top_k_) {
+      vector<pair<float, pair<int, int> > > score_index_pairs;
+      for (map<int, vector<int> >::iterator it = indices.begin();
+           it != indices.end(); ++it) {
+        int label = it->first;
+        const vector<int>& label_indices = it->second;
+        if (conf_scores.find(label) == conf_scores.end()) {
+          // Something bad happened for current label.
+          LOG(FATAL) << "Could not find location predictions for " << label;
+          continue;
+        }
+        const vector<float>& scores = conf_scores.find(label)->second;
+        for (int j = 0; j < label_indices.size(); ++j) {
+          int idx = label_indices[j];
+          CHECK_LT(idx, scores.size());
+          score_index_pairs.push_back(std::make_pair(
+                  scores[idx], std::make_pair(label, idx)));
+        }
+      }
+      // Keep top k results per image.
+      std::sort(score_index_pairs.begin(), score_index_pairs.end(),
+                SortScorePairDescend<pair<int, int> >);
+      score_index_pairs.resize(keep_top_k_);
+      // Store the new indices.
+      map<int, vector<int> > new_indices;
+      for (int j = 0; j < score_index_pairs.size(); ++j) {
+        int label = score_index_pairs[j].second.first;
+        int idx = score_index_pairs[j].second.second;
+        new_indices[label].push_back(idx);
+      }
+      all_indices.push_back(new_indices);
+      num_kept += keep_top_k_;
+    } else {
+      all_indices.push_back(indices);
+      num_kept += num_det;
+    }
+  }
+
+  vector<int> top_shape(2, 1);
+  top_shape.push_back(num_kept);
+  top_shape.push_back(7);
+  if (num_kept == 0) {
+    LOG(INFO) << "Couldn't find any detections";
+    top_shape[2] = 1;
+    top[0]->Reshape(top_shape);
+    caffe_set<Dtype>(top[0]->count(), -1, top[0]->mutable_cpu_data());
+    return;
+  }
+  top[0]->Reshape(top_shape);
+  Dtype* top_data = top[0]->mutable_cpu_data();
+
+  int count = 0;
+  boost::filesystem::path output_directory(output_directory_);
+  for (int i = 0; i < num; ++i) {
+    const map<int, vector<float> >& conf_scores = all_conf_scores[i];
+    const LabelBBox& decode_bboxes = all_decode_bboxes[i];
+    for (map<int, vector<int> >::iterator it = all_indices[i].begin();
+         it != all_indices[i].end(); ++it) {
+      int label = it->first;
+      if (conf_scores.find(label) == conf_scores.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find confidence predictions for " << label;
+        continue;
+      }
+      const vector<float>& scores = conf_scores.find(label)->second;
+      int loc_label = share_location_ ? -1 : label;
+      if (decode_bboxes.find(loc_label) == decode_bboxes.end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for " << loc_label;
+        continue;
+      }
+      const vector<NormalizedBBox>& bboxes =
+          decode_bboxes.find(loc_label)->second;
+      vector<int>& indices = it->second;
+      if (need_save_) {
+        CHECK(label_to_name_.find(label) != label_to_name_.end())
+          << "Cannot find label: " << label << " in the label map.";
+        CHECK_LT(name_count_, names_.size());
+      }
+      for (int j = 0; j < indices.size(); ++j) {
+        int idx = indices[j];
+        top_data[count * 7] = i;
+        top_data[count * 7 + 1] = label;
+        top_data[count * 7 + 2] = scores[idx];
+        NormalizedBBox clip_bbox;
+        ClipBBox(bboxes[idx], &clip_bbox);
+        top_data[count * 7 + 3] = clip_bbox.xmin();
+        top_data[count * 7 + 4] = clip_bbox.ymin();
+        top_data[count * 7 + 5] = clip_bbox.xmax();
+        top_data[count * 7 + 6] = clip_bbox.ymax();
+        if (need_save_) {
+          NormalizedBBox scale_bbox;
+          ScaleBBox(clip_bbox, sizes_[name_count_].first,
+                    sizes_[name_count_].second, &scale_bbox);
+          float score = top_data[count * 7 + 2];
+          float xmin = scale_bbox.xmin();
+          float ymin = scale_bbox.ymin();
+          float xmax = scale_bbox.xmax();
+          float ymax = scale_bbox.ymax();
+          ptree pt_xmin, pt_ymin, pt_width, pt_height;
+          pt_xmin.put<float>("", round(xmin * 100) / 100.);
+          pt_ymin.put<float>("", round(ymin * 100) / 100.);
+          pt_width.put<float>("", round((xmax - xmin) * 100) / 100.);
+          pt_height.put<float>("", round((ymax - ymin) * 100) / 100.);
+
+          ptree cur_bbox;
+          cur_bbox.push_back(std::make_pair("", pt_xmin));
+          cur_bbox.push_back(std::make_pair("", pt_ymin));
+          cur_bbox.push_back(std::make_pair("", pt_width));
+          cur_bbox.push_back(std::make_pair("", pt_height));
+
+          ptree cur_det;
+          cur_det.put("image_id", names_[name_count_]);
+          if (output_format_ == "ILSVRC") {
+            cur_det.put<int>("category_id", label);
+          } else {
+            cur_det.put("category_id", label_to_name_[label].c_str());
+          }
+          cur_det.add_child("bbox", cur_bbox);
+          cur_det.put<float>("score", score);
+
+          detections_.push_back(std::make_pair("", cur_det));
+        }
+        ++count;
+      }
+    }
+    if (need_save_) {
+      ++name_count_;
+      if (name_count_ % num_test_image_ == 0) {
+        if (output_format_ == "VOC") {
+          map<string, std::ofstream*> outfiles;
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            boost::filesystem::path file(
+                output_name_prefix_ + label_name + ".txt");
+            boost::filesystem::path out_file = output_directory / file;
+            outfiles[label_name] = new std::ofstream(out_file.string().c_str(),
+                std::ofstream::out);
+          }
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            string label_name = pt.get<string>("category_id");
+            if (outfiles.find(label_name) == outfiles.end()) {
+              std::cout << "Cannot find " << label_name << std::endl;
+              continue;
+            }
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            *(outfiles[label_name]) << image_name;
+            *(outfiles[label_name]) << " " << score;
+            *(outfiles[label_name]) << " " << bbox[0] << " " << bbox[1];
+            *(outfiles[label_name]) << " " << bbox[0] + bbox[2];
+            *(outfiles[label_name]) << " " << bbox[1] + bbox[3];
+            *(outfiles[label_name]) << std::endl;
+          }
+          for (int c = 0; c < num_classes_; ++c) {
+            if (c == background_label_id_) {
+              continue;
+            }
+            string label_name = label_to_name_[c];
+            outfiles[label_name]->flush();
+            outfiles[label_name]->close();
+            delete outfiles[label_name];
+          }
+        } else if (output_format_ == "COCO") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".json");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          boost::regex exp("\"(null|true|false|-?[0-9]+(\\.[0-9]+)?)\"");
+          ptree output;
+          output.add_child("detections", detections_);
+          std::stringstream ss;
+          write_json(ss, output);
+          std::string rv = boost::regex_replace(ss.str(), exp, "$1");
+          outfile << rv.substr(rv.find("["), rv.rfind("]") - rv.find("["))
+              << std::endl << "]" << std::endl;
+        } else if (output_format_ == "ILSVRC") {
+          boost::filesystem::path output_directory(output_directory_);
+          boost::filesystem::path file(output_name_prefix_ + ".txt");
+          boost::filesystem::path out_file = output_directory / file;
+          std::ofstream outfile;
+          outfile.open(out_file.string().c_str(), std::ofstream::out);
+
+          BOOST_FOREACH(ptree::value_type &det, detections_.get_child("")) {
+            ptree pt = det.second;
+            int label = pt.get<int>("category_id");
+            string image_name = pt.get<string>("image_id");
+            float score = pt.get<float>("score");
+            vector<int> bbox;
+            BOOST_FOREACH(ptree::value_type &elem, pt.get_child("bbox")) {
+              bbox.push_back(static_cast<int>(elem.second.get_value<float>()));
+            }
+            outfile << image_name << " " << label << " " << score;
+            outfile << " " << bbox[0] << " " << bbox[1];
+            outfile << " " << bbox[0] + bbox[2];
+            outfile << " " << bbox[1] + bbox[3];
+            outfile << std::endl;
+          }
+        }
+        name_count_ = 0;
+        detections_.clear();
+      }
+    }
+  }
+  if (visualize_) {
+#ifdef USE_OPENCV
+    vector<cv::Mat> cv_imgs;
+    this->data_transformer_->TransformInv(bottom[3], &cv_imgs);
+    vector<cv::Scalar> colors = GetColors(label_to_display_name_.size());
+    VisualizeBBox(cv_imgs, top[0], visualize_threshold_, colors,
+        label_to_display_name_);
+#endif  // USE_OPENCV
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU_FORWARD(DetectionOutputLayer, Forward);
+#endif
+
+INSTANTIATE_CLASS(DetectionOutputLayer);
+REGISTER_LAYER_CLASS(DetectionOutput);
+
+}  // namespace caffe

--- a/src/caffe/layers/normalize_layer.cpp
+++ b/src/caffe/layers/normalize_layer.cpp
@@ -1,0 +1,234 @@
+#include <vector>
+
+#include "caffe/filler.hpp"
+#include "caffe/layers/normalize_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void NormalizeLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  CHECK_GE(bottom[0]->num_axes(), 2)
+      << "Number of axes of bottom blob must be >=2.";
+  buffer_.Reshape(1, bottom[0]->channels(),
+                   bottom[0]->height(), bottom[0]->width());
+  buffer_channel_.Reshape(1, bottom[0]->channels(), 1, 1);
+  buffer_spatial_.Reshape(1, 1, bottom[0]->height(), bottom[0]->width());
+  NormalizeParameter norm_param = this->layer_param().norm_param();
+  across_spatial_ = norm_param.across_spatial();
+  if (across_spatial_) {
+    norm_.Reshape(bottom[0]->num(), 1, 1, 1);
+  } else {
+    norm_.Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  }
+  eps_ = norm_param.eps();
+  int channels = bottom[0]->channels();
+  int spatial_dim = bottom[0]->width() * bottom[0]->height();
+  sum_channel_multiplier_.Reshape(1, channels, 1, 1);
+  caffe_set(channels, Dtype(1), sum_channel_multiplier_.mutable_cpu_data());
+  sum_spatial_multiplier_.Reshape(
+      1, 1, bottom[0]->height(), bottom[0]->width());
+  caffe_set(spatial_dim, Dtype(1), sum_spatial_multiplier_.mutable_cpu_data());
+  channel_shared_ = norm_param.channel_shared();
+  if (this->blobs_.size() > 0) {
+    LOG(INFO) << "Skipping parameter initialization";
+  } else {
+    this->blobs_.resize(1);
+    if (channel_shared_) {
+      this->blobs_[0].reset(new Blob<Dtype>(vector<int>(0)));
+    } else {
+      this->blobs_[0].reset(new Blob<Dtype>(vector<int>(1, channels)));
+    }
+    shared_ptr<Filler<Dtype> > scale_filler;
+    if (norm_param.has_scale_filler()) {
+      scale_filler.reset(GetFiller<Dtype>(norm_param.scale_filler()));
+    } else {
+      FillerParameter filler_param;
+      filler_param.set_type("constant");
+      filler_param.set_value(1.0);
+      scale_filler.reset(GetFiller<Dtype>(filler_param));
+    }
+    scale_filler->Fill(this->blobs_[0].get());
+  }
+  if (channel_shared_) {
+    CHECK_EQ(this->blobs_[0]->count(), 1)
+        << "Scale size is inconsistent with prototxt config";
+  } else {
+    CHECK_EQ(this->blobs_[0]->count(), channels)
+        << "Scale size is inconsistent with prototxt config";
+  }
+  this->param_propagate_down_.resize(this->blobs_.size(), true);
+}
+
+template <typename Dtype>
+void NormalizeLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  CHECK_GE(bottom[0]->num_axes(), 2)
+      << "Number of axes of bottom blob must be >=2.";
+  top[0]->ReshapeLike(*bottom[0]);
+  buffer_.Reshape(1, bottom[0]->channels(),
+                   bottom[0]->height(), bottom[0]->width());
+  if (!across_spatial_) {
+    norm_.Reshape(bottom[0]->num(), 1, bottom[0]->height(), bottom[0]->width());
+  }
+  int spatial_dim = bottom[0]->height() * bottom[0]->width();
+  if (spatial_dim != sum_spatial_multiplier_.count()) {
+    sum_spatial_multiplier_.Reshape(
+        1, 1, bottom[0]->height(), bottom[0]->width());
+    caffe_set(spatial_dim, Dtype(1),
+              sum_spatial_multiplier_.mutable_cpu_data());
+    buffer_spatial_.Reshape(1, 1, bottom[0]->height(), bottom[0]->width());
+  }
+}
+
+template <typename Dtype>
+void NormalizeLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  const Dtype* scale = this->blobs_[0]->cpu_data();
+  Dtype* buffer_data = buffer_.mutable_cpu_data();
+  Dtype* norm_data = norm_.mutable_cpu_data();
+  // add eps to avoid overflow
+  caffe_set<Dtype>(norm_.count(), Dtype(eps_), norm_data);
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.cpu_data();
+  const Dtype* sum_spatial_multiplier = sum_spatial_multiplier_.cpu_data();
+  int num = bottom[0]->num();
+  int dim = bottom[0]->count() / num;
+  int spatial_dim = bottom[0]->height() * bottom[0]->width();
+  int channels = bottom[0]->channels();
+  for (int n = 0; n < num; ++n) {
+    caffe_sqr<Dtype>(dim, bottom_data, buffer_data);
+    if (across_spatial_) {
+      // add eps to avoid overflow
+      norm_data[n] = pow(caffe_cpu_asum<Dtype>(dim, buffer_data)+eps_,
+                         Dtype(0.5));
+      caffe_cpu_scale<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_data,
+                             top_data);
+    } else {
+      caffe_cpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
+                            buffer_data, sum_channel_multiplier, Dtype(1),
+                            norm_data);
+      // compute norm
+      caffe_powx<Dtype>(spatial_dim, norm_data, Dtype(0.5), norm_data);
+      // scale the layer
+      caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                            1, Dtype(1), sum_channel_multiplier, norm_data,
+                            Dtype(0), buffer_data);
+      caffe_div<Dtype>(dim, bottom_data, buffer_data, top_data);
+      norm_data += spatial_dim;
+    }
+    // scale the output
+    if (channel_shared_) {
+      caffe_scal<Dtype>(dim, scale[0], top_data);
+    } else {
+      caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                            1, Dtype(1), scale, sum_spatial_multiplier,
+                            Dtype(0),
+                            buffer_data);
+      caffe_mul<Dtype>(dim, top_data, buffer_data, top_data);
+    }
+    bottom_data += dim;
+    top_data += dim;
+  }
+}
+
+template <typename Dtype>
+void NormalizeLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+    const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  const Dtype* top_diff = top[0]->cpu_diff();
+  const Dtype* top_data = top[0]->cpu_data();
+  const Dtype* bottom_data = bottom[0]->cpu_data();
+  Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+  const Dtype* scale = this->blobs_[0]->cpu_data();
+  const Dtype* norm_data = norm_.cpu_data();
+  Dtype* buffer_data = buffer_.mutable_cpu_data();
+  Dtype* buffer_channel = buffer_channel_.mutable_cpu_data();
+  Dtype* buffer_spatial = buffer_spatial_.mutable_cpu_data();
+  const Dtype* sum_channel_multiplier = sum_channel_multiplier_.cpu_data();
+  const Dtype* sum_spatial_multiplier = sum_spatial_multiplier_.cpu_data();
+  int count = top[0]->count();
+  int num = top[0]->num();
+  int dim = count / num;
+  int spatial_dim = top[0]->height() * top[0]->width();
+  int channels = top[0]->channels();
+
+  // Propagate to param
+  if (this->param_propagate_down_[0]) {
+    Dtype* scale_diff = this->blobs_[0]->mutable_cpu_diff();
+    if (channel_shared_) {
+      scale_diff[0] +=
+          caffe_cpu_dot<Dtype>(count, top_data, top_diff) / scale[0];
+    } else {
+      for (int n = 0; n < num; ++n) {
+        caffe_mul<Dtype>(dim, top_data+n*dim, top_diff+n*dim, buffer_data);
+        caffe_cpu_gemv<Dtype>(CblasNoTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_spatial_multiplier, Dtype(0),
+                              buffer_channel);
+        // store a / scale[i] in buffer_data temporary
+        caffe_div<Dtype>(channels, buffer_channel, scale, buffer_channel);
+        caffe_add<Dtype>(channels, buffer_channel, scale_diff, scale_diff);
+      }
+    }
+  }
+
+  // Propagate to bottom
+  if (propagate_down[0]) {
+    for (int n = 0; n < num; ++n) {
+      if (across_spatial_) {
+        Dtype a = caffe_cpu_dot<Dtype>(dim, bottom_data, top_diff);
+        caffe_cpu_scale<Dtype>(dim, a / norm_data[n] / norm_data[n],
+                               bottom_data, bottom_diff);
+        caffe_sub<Dtype>(dim, top_diff, bottom_diff, bottom_diff);
+        caffe_scal<Dtype>(dim, Dtype(1.0 / norm_data[n]), bottom_diff);
+      } else {
+        // dot product between bottom_data and top_diff
+        caffe_mul<Dtype>(dim, bottom_data, top_diff, buffer_data);
+        caffe_cpu_gemv<Dtype>(CblasTrans, channels, spatial_dim, Dtype(1),
+                              buffer_data, sum_channel_multiplier, Dtype(0),
+                              buffer_spatial);
+        // scale bottom_diff
+        caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier,
+                              buffer_spatial, Dtype(0), buffer_data);
+        caffe_mul<Dtype>(dim, bottom_data, buffer_data, bottom_diff);
+        // divide by square of norm
+        caffe_powx<Dtype>(spatial_dim, norm_data, Dtype(2), buffer_spatial);
+        caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier,
+                              buffer_spatial, Dtype(0), buffer_data);
+        caffe_div<Dtype>(dim, bottom_diff, buffer_data, bottom_diff);
+        // subtract
+        caffe_sub<Dtype>(dim, top_diff, bottom_diff, bottom_diff);
+        // divide by norm
+        caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), sum_channel_multiplier, norm_data,
+                              Dtype(0), buffer_data);
+        caffe_div<Dtype>(dim, bottom_diff, buffer_data, bottom_diff);
+        norm_data += spatial_dim;
+      }
+      // scale the diff
+      if (channel_shared_) {
+        caffe_scal<Dtype>(dim, scale[0], bottom_diff);
+      } else {
+        caffe_cpu_gemm<Dtype>(CblasNoTrans, CblasNoTrans, channels, spatial_dim,
+                              1, Dtype(1), scale, sum_spatial_multiplier,
+                              Dtype(0), buffer_data);
+        caffe_mul<Dtype>(dim, bottom_diff, buffer_data, bottom_diff);
+      }
+      bottom_data += dim;
+      top_diff += dim;
+      bottom_diff += dim;
+    }
+  }
+}
+
+
+#ifdef CPU_ONLY
+STUB_GPU(NormalizeLayer);
+#endif
+
+INSTANTIATE_CLASS(NormalizeLayer);
+REGISTER_LAYER_CLASS(Normalize);
+
+}  // namespace caffe

--- a/src/caffe/layers/permute_layer.cpp
+++ b/src/caffe/layers/permute_layer.cpp
@@ -1,0 +1,143 @@
+#include <vector>
+
+#include "caffe/layers/permute_layer.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void Permute(const int count, Dtype* bottom_data, const bool forward,
+    const int* permute_order, const int* old_steps, const int* new_steps,
+    const int num_axes, Dtype* top_data) {
+#pragma omp parallel for
+    for (int i = 0; i < count; ++i) {
+      int old_idx = 0;
+      int idx = i;
+      for (int j = 0; j < num_axes; ++j) {
+        int order = permute_order[j];
+        old_idx += (idx / new_steps[j]) * old_steps[order];
+        idx %= new_steps[j];
+      }
+      if (forward) {
+        top_data[i] = bottom_data[old_idx];
+      } else {
+        bottom_data[old_idx] = top_data[i];
+      }
+    }
+}
+
+template <typename Dtype>
+void PermuteLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  PermuteParameter permute_param = this->layer_param_.permute_param();
+  CHECK_EQ(bottom.size(), 1);
+  num_axes_ = bottom[0]->num_axes();
+  vector<int> orders;
+  // Push the specified new orders.
+  for (int i = 0; i < permute_param.order_size(); ++i) {
+    int order = permute_param.order(i);
+    CHECK_LT(order, num_axes_)
+        << "order should be less than the input dimension.";
+    if (std::find(orders.begin(), orders.end(), order) != orders.end()) {
+      LOG(FATAL) << "there are duplicate orders";
+    }
+    orders.push_back(order);
+  }
+  // Push the rest orders. And save original step sizes for each axis.
+  for (int i = 0; i < num_axes_; ++i) {
+    if (std::find(orders.begin(), orders.end(), i) == orders.end()) {
+      orders.push_back(i);
+    }
+  }
+  CHECK_EQ(num_axes_, orders.size());
+  // Check if we need to reorder the data or keep it.
+  need_permute_ = false;
+  for (int i = 0; i < num_axes_; ++i) {
+    if (orders[i] != i) {
+      // As long as there is one order which is different from the natural order
+      // of the data, we need to permute. Otherwise, we share the data and diff.
+      need_permute_ = true;
+      break;
+    }
+  }
+
+  vector<int> top_shape(num_axes_, 1);
+  permute_order_.Reshape(num_axes_, 1, 1, 1);
+  old_steps_.Reshape(num_axes_, 1, 1, 1);
+  new_steps_.Reshape(num_axes_, 1, 1, 1);
+  for (int i = 0; i < num_axes_; ++i) {
+    permute_order_.mutable_cpu_data()[i] = orders[i];
+    top_shape[i] = bottom[0]->shape(orders[i]);
+  }
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Dtype>
+void PermuteLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  vector<int> top_shape;
+  for (int i = 0; i < num_axes_; ++i) {
+    if (i == num_axes_ - 1) {
+      old_steps_.mutable_cpu_data()[i] = 1;
+    } else {
+      old_steps_.mutable_cpu_data()[i] = bottom[0]->count(i + 1);
+    }
+    top_shape.push_back(bottom[0]->shape(permute_order_.cpu_data()[i]));
+  }
+  top[0]->Reshape(top_shape);
+
+  for (int i = 0; i < num_axes_; ++i) {
+    if (i == num_axes_ - 1) {
+      new_steps_.mutable_cpu_data()[i] = 1;
+    } else {
+      new_steps_.mutable_cpu_data()[i] = top[0]->count(i + 1);
+    }
+  }
+}
+
+template <typename Dtype>
+void PermuteLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  if (need_permute_) {
+    Dtype* bottom_data = bottom[0]->mutable_cpu_data();
+    Dtype* top_data = top[0]->mutable_cpu_data();
+    const int top_count = top[0]->count();
+    const int* permute_order = permute_order_.cpu_data();
+    const int* old_steps = old_steps_.cpu_data();
+    const int* new_steps = new_steps_.cpu_data();
+    bool forward = true;
+    Permute(top_count, bottom_data, forward, permute_order, old_steps,
+            new_steps, num_axes_, top_data);
+  } else {
+    // If there is no need to permute, we share data to save memory.
+    top[0]->ShareData(*bottom[0]);
+  }
+}
+
+template <typename Dtype>
+void PermuteLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
+      const vector<bool>& propagate_down, const vector<Blob<Dtype>*>& bottom) {
+  if (need_permute_) {
+    Dtype* top_diff = top[0]->mutable_cpu_diff();
+    Dtype* bottom_diff = bottom[0]->mutable_cpu_diff();
+    const int top_count = top[0]->count();
+    const int* permute_order = permute_order_.cpu_data();
+    const int* old_steps = old_steps_.cpu_data();
+    const int* new_steps = new_steps_.cpu_data();
+    bool forward = false;
+    Permute(top_count, bottom_diff, forward, permute_order, old_steps,
+            new_steps, num_axes_, top_diff);
+  } else {
+    // If there is no need to permute, we share diff to save memory.
+    bottom[0]->ShareDiff(*top[0]);
+  }
+}
+
+#ifdef CPU_ONLY
+STUB_GPU(PermuteLayer);
+#endif
+
+INSTANTIATE_CLASS(PermuteLayer);
+REGISTER_LAYER_CLASS(Permute);
+
+}  // namespace caffe

--- a/src/caffe/layers/prior_box_layer.cpp
+++ b/src/caffe/layers/prior_box_layer.cpp
@@ -1,0 +1,166 @@
+#include <algorithm>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "caffe/layers/prior_box_layer.hpp"
+
+namespace caffe {
+
+template <typename Dtype>
+void PriorBoxLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const PriorBoxParameter& prior_box_param =
+      this->layer_param_.prior_box_param();
+  CHECK(prior_box_param.has_min_size()) << "must provide min_size.";
+  min_size_ = prior_box_param.min_size();
+  CHECK_GT(min_size_, 0) << "min_size must be positive.";
+  max_size_ = -1;
+  aspect_ratios_.clear();
+  aspect_ratios_.push_back(1.);
+  flip_ = prior_box_param.flip();
+  for (int i = 0; i < prior_box_param.aspect_ratio_size(); ++i) {
+    float ar = prior_box_param.aspect_ratio(i);
+    bool already_exist = false;
+    for (int j = 0; j < aspect_ratios_.size(); ++j) {
+      if (fabs(ar - aspect_ratios_[j]) < 1e-6) {
+        already_exist = true;
+        break;
+      }
+    }
+    if (!already_exist) {
+      aspect_ratios_.push_back(ar);
+      if (flip_) {
+        aspect_ratios_.push_back(1./ar);
+      }
+    }
+  }
+  num_priors_ = aspect_ratios_.size();
+  if (prior_box_param.has_max_size()) {
+    max_size_ = prior_box_param.max_size();
+    CHECK_GT(max_size_, min_size_) << "max_size must be greater than min_size.";
+    num_priors_ += 1;
+  }
+  clip_ = prior_box_param.clip();
+  if (prior_box_param.variance_size() > 1) {
+    // Must and only provide 4 variance.
+    CHECK_EQ(prior_box_param.variance_size(), 4);
+    for (int i = 0; i < prior_box_param.variance_size(); ++i) {
+      CHECK_GT(prior_box_param.variance(i), 0);
+      variance_.push_back(prior_box_param.variance(i));
+    }
+  } else if (prior_box_param.variance_size() == 1) {
+    CHECK_GT(prior_box_param.variance(0), 0);
+    variance_.push_back(prior_box_param.variance(0));
+  } else {
+    // Set default to 0.1.
+    variance_.push_back(0.1);
+  }
+}
+
+template <typename Dtype>
+void PriorBoxLayer<Dtype>::Reshape(const vector<Blob<Dtype>*>& bottom,
+      const vector<Blob<Dtype>*>& top) {
+  const int layer_width = bottom[0]->width();
+  const int layer_height = bottom[0]->height();
+  vector<int> top_shape(3, 1);
+  // Since all images in a batch has same height and width, we only need to
+  // generate one set of priors which can be shared across all images.
+  top_shape[0] = 1;
+  // 2 channels. First channel stores the mean of each prior coordinate.
+  // Second channel stores the variance of each prior coordinate.
+  top_shape[1] = 2;
+  top_shape[2] = layer_width * layer_height * num_priors_ * 4;
+  CHECK_GT(top_shape[2], 0);
+  top[0]->Reshape(top_shape);
+}
+
+template <typename Dtype>
+void PriorBoxLayer<Dtype>::Forward_cpu(const vector<Blob<Dtype>*>& bottom,
+    const vector<Blob<Dtype>*>& top) {
+  const int layer_width = bottom[0]->width();
+  const int layer_height = bottom[0]->height();
+  const int img_width = bottom[1]->width();
+  const int img_height = bottom[1]->height();
+  const float step_x = static_cast<float>(img_width) / layer_width;
+  const float step_y = static_cast<float>(img_height) / layer_height;
+  Dtype* top_data = top[0]->mutable_cpu_data();
+  int dim = layer_height * layer_width * num_priors_ * 4;
+  int idx = 0;
+  for (int h = 0; h < layer_height; ++h) {
+    for (int w = 0; w < layer_width; ++w) {
+      float center_x = (w + 0.5) * step_x;
+      float center_y = (h + 0.5) * step_y;
+      float box_width, box_height;
+      // first prior: aspect_ratio = 1, size = min_size
+      box_width = box_height = min_size_;
+      // xmin
+      top_data[idx++] = (center_x - box_width / 2.) / img_width;
+      // ymin
+      top_data[idx++] = (center_y - box_height / 2.) / img_height;
+      // xmax
+      top_data[idx++] = (center_x + box_width / 2.) / img_width;
+      // ymax
+      top_data[idx++] = (center_y + box_height / 2.) / img_height;
+
+      if (max_size_ > 0) {
+        // second prior: aspect_ratio = 1, size = sqrt(min_size * max_size)
+        box_width = box_height = sqrt(min_size_ * max_size_);
+        // xmin
+        top_data[idx++] = (center_x - box_width / 2.) / img_width;
+        // ymin
+        top_data[idx++] = (center_y - box_height / 2.) / img_height;
+        // xmax
+        top_data[idx++] = (center_x + box_width / 2.) / img_width;
+        // ymax
+        top_data[idx++] = (center_y + box_height / 2.) / img_height;
+      }
+
+      // rest of priors
+      for (int r = 0; r < aspect_ratios_.size(); ++r) {
+        float ar = aspect_ratios_[r];
+        if (fabs(ar - 1.) < 1e-6) {
+          continue;
+        }
+        box_width = min_size_ * sqrt(ar);
+        box_height = min_size_ / sqrt(ar);
+        // xmin
+        top_data[idx++] = (center_x - box_width / 2.) / img_width;
+        // ymin
+        top_data[idx++] = (center_y - box_height / 2.) / img_height;
+        // xmax
+        top_data[idx++] = (center_x + box_width / 2.) / img_width;
+        // ymax
+        top_data[idx++] = (center_y + box_height / 2.) / img_height;
+      }
+    }
+  }
+  // clip the prior's coordidate such that it is within [0, 1]
+  if (clip_) {
+    for (int d = 0; d < dim; ++d) {
+      top_data[d] = std::min<Dtype>(std::max<Dtype>(top_data[d], 0.), 1.);
+    }
+  }
+  // set the variance.
+  top_data += top[0]->offset(0, 1);
+  if (variance_.size() == 1) {
+    caffe_set<Dtype>(dim, Dtype(variance_[0]), top_data);
+  } else {
+    int count = 0;
+    for (int h = 0; h < layer_height; ++h) {
+      for (int w = 0; w < layer_width; ++w) {
+        for (int i = 0; i < num_priors_; ++i) {
+          for (int j = 0; j < 4; ++j) {
+            top_data[count] = variance_[j];
+            ++count;
+          }
+        }
+      }
+    }
+  }
+}
+
+INSTANTIATE_CLASS(PriorBoxLayer);
+REGISTER_LAYER_CLASS(PriorBox);
+
+}  // namespace caffe

--- a/src/caffe/proto/caffe.proto
+++ b/src/caffe/proto/caffe.proto
@@ -463,6 +463,15 @@ message LayerParameter {
   optional TileParameter tile_param = 138;
   optional WindowDataParameter window_data_param = 129;
   optional RemoteDataParameter remote_data_param = 148;
+
+  optional AnnotatedDataParameter annotated_data_param = 200;
+  optional DetectionEvaluateParameter detection_evaluate_param = 205;
+  optional DetectionOutputParameter detection_output_param = 204;
+  optional MultiBoxLossParameter multibox_loss_param = 201;
+  optional NormalizeParameter norm_param = 206;
+  optional PermuteParameter permute_param = 202;
+  optional PriorBoxParameter prior_box_param = 203;
+  optional VideoDataParameter video_data_param = 207;
 }
 
 // Message that stores parameters used to apply transformation
@@ -486,6 +495,17 @@ message TransformationParameter {
   optional bool force_color = 6 [default = false];
   // Force the decoded image to have 1 color channels.
   optional bool force_gray = 7 [default = false];
+
+  optional uint32 crop_h = 11 [default = 0];
+  optional uint32 crop_w = 12 [default = 0];
+
+  // Resize policy
+  optional ResizeParameter resize_param = 8;
+  // Noise policy
+  optional NoiseParameter noise_param = 9;
+  // Constraint for emitting the annotation after transformation.
+  optional EmitConstraint emit_constraint = 10;
+
 }
 
 // Message that stores parameters shared by loss layers
@@ -559,7 +579,6 @@ message ConcatParameter {
     DEFAULT = 0;
     CAFFE = 1;
     MKL2017 = 3;
-    MKLDNN = 4;
   }
   optional Engine engine = 3 [default = DEFAULT];}
 
@@ -1522,3 +1541,390 @@ message PReLUParameter {
   // Whether or not slope paramters are shared across channels.
   optional bool channel_shared = 2 [default = false];
 }
+
+
+// The label (display) name and label id.
+message LabelMapItem {
+  // Both name and label are required.
+  optional string name = 1;
+  optional int32 label = 2;
+  // display_name is optional.
+  optional string display_name = 3;
+}
+
+message LabelMap {
+  repeated LabelMapItem item = 1;
+}
+
+// Sample a bbox in the normalized space [0, 1] with provided constraints.
+message Sampler {
+  // Minimum scale of the sampled bbox.
+  optional float min_scale = 1 [default = 1.];
+  // Maximum scale of the sampled bbox.
+  optional float max_scale = 2 [default = 1.];
+
+  // Minimum aspect ratio of the sampled bbox.
+  optional float min_aspect_ratio = 3 [default = 1.];
+  // Maximum aspect ratio of the sampled bbox.
+  optional float max_aspect_ratio = 4 [default = 1.];
+}
+
+// Constraints for selecting sampled bbox.
+message SampleConstraint {
+  // Minimum Jaccard overlap between sampled bbox and all bboxes in
+  // AnnotationGroup.
+  optional float min_jaccard_overlap = 1;
+  // Maximum Jaccard overlap between sampled bbox and all bboxes in
+  // AnnotationGroup.
+  optional float max_jaccard_overlap = 2;
+
+  // Minimum coverage of sampled bbox by all bboxes in AnnotationGroup.
+  optional float min_sample_coverage = 3;
+  // Maximum coverage of sampled bbox by all bboxes in AnnotationGroup.
+  optional float max_sample_coverage = 4;
+
+  // Minimum coverage of all bboxes in AnnotationGroup by sampled bbox.
+  optional float min_object_coverage = 5;
+  // Maximum coverage of all bboxes in AnnotationGroup by sampled bbox.
+  optional float max_object_coverage = 6;
+}
+
+// Sample a batch of bboxes with provided constraints.
+message BatchSampler {
+  // Use original image as the source for sampling.
+  optional bool use_original_image = 1 [default = true];
+
+  // Constraints for sampling bbox.
+  optional Sampler sampler = 2;
+
+  // Constraints for determining if a sampled bbox is positive or negative.
+  optional SampleConstraint sample_constraint = 3;
+
+  // If provided, break when found certain number of samples satisfing the
+  // sample_constraint.
+  optional uint32 max_sample = 4;
+
+  // Maximum number of trials for sampling to avoid infinite loop.
+  optional uint32 max_trials = 5 [default = 100];
+}
+
+// Condition for emitting annotations.
+message EmitConstraint {
+  enum EmitType {
+    CENTER = 0;
+    MIN_OVERLAP = 1;
+  }
+  optional EmitType emit_type = 1 [default = CENTER];
+  // If emit_type is MIN_OVERLAP, provide the emit_overlap.
+  optional float emit_overlap = 2;
+}
+
+// The normalized bounding box [0, 1] w.r.t. the input image size.
+message NormalizedBBox {
+  optional float xmin = 1;
+  optional float ymin = 2;
+  optional float xmax = 3;
+  optional float ymax = 4;
+  optional int32 label = 5;
+  optional bool difficult = 6;
+  optional float score = 7;
+  optional float size = 8;
+}
+
+// Annotation for each object instance.
+message Annotation {
+  optional int32 instance_id = 1 [default = 0];
+  optional NormalizedBBox bbox = 2;
+}
+
+// Group of annotations for a particular label.
+message AnnotationGroup {
+  optional int32 group_label = 1;
+  repeated Annotation annotation = 2;
+}
+
+// An extension of Datum which contains "rich" annotations.
+message AnnotatedDatum {
+  enum AnnotationType {
+    BBOX = 0;
+  }
+  optional Datum datum = 1;
+  // If there are "rich" annotations, specify the type of annotation.
+  // Currently it only supports bounding box.
+  // If there are no "rich" annotations, use label in datum instead.
+  optional AnnotationType type = 2;
+  // Each group contains annotation for a particular class.
+  repeated AnnotationGroup annotation_group = 3;
+}
+
+message ResizeParameter {
+  //Probability of using this resize policy
+  optional float prob = 1 [default = 1];
+
+  enum Resize_mode {
+    WARP = 1;
+    FIT_SMALL_SIZE = 2;
+    FIT_LARGE_SIZE_AND_PAD = 3;
+  }
+  optional Resize_mode resize_mode = 2 [default = WARP];
+  optional uint32 height = 3 [default = 0];
+  optional uint32 width = 4 [default = 0];
+
+  enum Pad_mode {
+    CONSTANT = 1;
+    MIRRORED = 2;
+    REPEAT_NEAREST = 3;
+  }
+  // Padding mode for BE_SMALL_SIZE_AND_PAD mode and object centering
+  optional Pad_mode pad_mode = 5 [default = CONSTANT];
+  // if specified can be repeated once (would fill all the channels)
+  // or can be repeated the same number of times as channels
+  // (would use it them to the corresponding channel)
+  repeated float pad_value = 6;
+
+  enum Interp_mode { //Same as in OpenCV
+    LINEAR = 1;
+    AREA = 2;
+    NEAREST = 3;
+    CUBIC = 4;
+    LANCZOS4 = 5;
+  }
+  //interpolation for for resizing
+  repeated Interp_mode interp_mode = 7;
+}
+
+message SaltPepperParameter {
+  //Percentage of pixels
+  optional float fraction = 1 [default = 0];
+  repeated float value = 2;
+}
+
+// Message that stores parameters used by data transformer for transformation
+// policy
+message NoiseParameter {
+  //Probability of using this resize policy
+  optional float prob = 1 [default = 0];
+  // Histogram equalized
+  optional bool hist_eq = 2 [default = false];
+  // Color inversion
+  optional bool inverse = 3 [default = false];
+  // Grayscale
+  optional bool decolorize = 4 [default = false];
+  // Gaussian blur
+  optional bool gauss_blur = 5 [default = false];
+
+  // JPEG compression quality (-1 = no compression)
+  optional float jpeg = 6 [default = -1];
+
+  // Posterization
+  optional bool posterize = 7 [default = false];
+
+  // Erosion
+  optional bool erode = 8 [default = false];
+
+  // Salt-and-pepper noise
+  optional bool saltpepper = 9 [default = false];
+
+  optional SaltPepperParameter saltpepper_param = 10;
+
+  // Local histogram equalization
+  optional bool clahe = 11 [default = false];
+
+  // Color space conversion
+  optional bool convert_to_hsv = 12 [default = false];
+
+  // Color space conversion
+  optional bool convert_to_lab = 13 [default = false];
+}
+
+message AnnotatedDataParameter {
+  // Define the sampler.
+  repeated BatchSampler batch_sampler = 1;
+  // Store label name and label id in LabelMap format.
+  optional string label_map_file = 2;
+}
+
+// Message that store parameters used by DetectionEvaluateLayer
+message DetectionEvaluateParameter {
+  // Number of classes that are actually predicted. Required!
+  optional uint32 num_classes = 1;
+  // Label id for background class. Needed for sanity check so that
+  // background class is neither in the ground truth nor the detections.
+  optional uint32 background_label_id = 2 [default = 0];
+  // Threshold for deciding true/false positive.
+  optional float overlap_threshold = 3 [default = 0.5];
+  // If true, also consider difficult ground truth for evaluation.
+  optional bool evaluate_difficult_gt = 4 [default = true];
+  // A file which contains a list of names and sizes with same order
+  // of the input DB. The file is in the following format:
+  //    name height width
+  //    ...
+  // If provided, we will scale the prediction and ground truth NormalizedBBox
+  // for evaluation.
+  optional string name_size_file = 5;
+}
+
+message NonMaximumSuppressionParameter {
+  // Threshold to be used in nms.
+  optional float nms_threshold = 1 [default = 0.3];
+  // Maximum number of results to be kept.
+  optional int32 top_k = 2;
+}
+
+message SaveOutputParameter {
+  // Output directory. If not empty, we will save the results.
+  optional string output_directory = 1;
+  // Output name prefix.
+  optional string output_name_prefix = 2;
+  // Output format.
+  //    VOC - PASCAL VOC output format.
+  //    COCO - MS COCO output format.
+  optional string output_format = 3;
+  // If you want to output results, must also provide the following two files.
+  // Otherwise, we will ignore saving results.
+  // label map file.
+  optional string label_map_file = 4;
+  // A file which contains a list of names and sizes with same order
+  // of the input DB. The file is in the following format:
+  //    name height width
+  //    ...
+  optional string name_size_file = 5;
+  // Number of test images. It can be less than the lines specified in
+  // name_size_file. For example, when we only want to evaluate on part
+  // of the test images.
+  optional uint32 num_test_image = 6;
+}
+
+// Message that store parameters used by DetectionOutputLayer
+message DetectionOutputParameter {
+  // Number of classes to be predicted. Required!
+  optional uint32 num_classes = 1;
+  // If true, bounding box are shared among different classes.
+  optional bool share_location = 2 [default = true];
+  // Background label id. If there is no background class,
+  // set it as -1.
+  optional int32 background_label_id = 3 [default = 0];
+  // Parameters used for non maximum suppression.
+  optional NonMaximumSuppressionParameter nms_param = 4;
+  // Parameters used for saving detection results.
+  optional SaveOutputParameter save_output_param = 5;
+  // Type of coding method for bbox.
+  optional PriorBoxParameter.CodeType code_type = 6 [default = CORNER];
+  // If true, variance is encoded in target; otherwise we need to adjust the
+  // predicted offset accordingly.
+  optional bool variance_encoded_in_target = 8 [default = false];
+  // Number of total bboxes to be kept per image after nms step.
+  // -1 means keeping all bboxes after nms step.
+  optional int32 keep_top_k = 7 [default = -1];
+  // Only consider detections whose confidences are larger than a threshold.
+  // If not provided, consider all boxes.
+  optional float confidence_threshold = 9;
+  // If true, visualize the detection results.
+  optional bool visualize = 10 [default = false];
+  // The threshold used to visualize the detection results.
+  optional float visualize_threshold = 11;
+}
+
+// Message that store parameters used by MultiBoxLossLayer
+message MultiBoxLossParameter {
+  // Localization loss type.
+  enum LocLossType {
+    L2 = 0;
+    SMOOTH_L1 = 1;
+  }
+  optional LocLossType loc_loss_type = 1 [default = SMOOTH_L1];
+  // Confidence loss type.
+  enum ConfLossType {
+    SOFTMAX = 0;
+    LOGISTIC = 1;
+  }
+  optional ConfLossType conf_loss_type = 2 [default = SOFTMAX];
+  // Weight for localization loss.
+  optional float loc_weight = 3 [default = 1.0];
+  // Number of classes to be predicted. Required!
+  optional uint32 num_classes = 4;
+  // If true, bounding box are shared among different classes.
+  optional bool share_location = 5 [default = true];
+  // Matching method during training.
+  enum MatchType {
+    BIPARTITE = 0;
+    PER_PREDICTION = 1;
+  }
+  optional MatchType match_type = 6 [default = PER_PREDICTION];
+  // If match_type is PER_PREDICTION, use overlap_threshold to
+  // determine the extra matching bboxes.
+  optional float overlap_threshold = 7 [default = 0.5];
+  // Use prior for matching.
+  optional bool use_prior_for_matching = 8 [default = true];
+  // Background label id.
+  optional uint32 background_label_id = 9 [default = 0];
+  // If true, also consider difficult ground truth.
+  optional bool use_difficult_gt = 10 [default = true];
+  // If true, perform negative mining.
+  optional bool do_neg_mining = 11 [default = true];
+  // The negative/positive ratio.
+  optional float neg_pos_ratio = 12 [default = 3.0];
+  // The negative overlap upperbound for the unmatched predictions.
+  optional float neg_overlap = 13 [default = 0.5];
+  // Type of coding method for bbox.
+  optional PriorBoxParameter.CodeType code_type = 14 [default = CORNER];
+  // If true, encode the variance of prior box in the loc loss target instead of
+  // in bbox.
+  optional bool encode_variance_in_target = 16 [default = false];
+  // If true, map all object classes to agnostic class. It is useful for learning
+  // objectness detector.
+  optional bool map_object_to_agnostic = 17 [default = false];
+}
+
+// Message that stores parameters used by NormalizeLayer
+message NormalizeParameter {
+  optional bool across_spatial = 1 [default = true];
+  // Initial value of scale. Default is 1.0 for all
+  optional FillerParameter scale_filler = 2;
+  // Whether or not scale parameters are shared across channels.
+  optional bool channel_shared = 3 [default = true];
+  // Epsilon for not dividing by zero while normalizing variance
+  optional float eps = 4 [default = 1e-10];
+}
+
+message PermuteParameter {
+  // The new orders of the axes of data. Notice it should be with
+  // in the same range as the input data, and it starts from 0.
+  // Do not provide repeated order.
+  repeated uint32 order = 1;
+}
+
+// Message that store parameters used by PriorBoxLayer
+message PriorBoxParameter {
+  // Encode/decode type.
+  enum CodeType {
+    CORNER = 1;
+    CENTER_SIZE = 2;
+  }
+  // Minimum box size (in pixels). Required!
+  optional float min_size = 1;
+  // Maximum box size (in pixels). Required!
+  optional float max_size = 2;
+  // Various of aspect ratios. Duplicate ratios will be ignored.
+  // If none is provided, we use default ratio 1.
+  repeated float aspect_ratio = 3;
+  // If true, will flip each aspect ratio.
+  // For example, if there is aspect ratio "r",
+  // we will generate aspect ratio "1.0/r" as well.
+  optional bool flip = 4 [default = true];
+  // If true, will clip the prior so that it is within [0, 1]
+  optional bool clip = 5 [default = true];
+  // Variance for adjusting the prior bboxes.
+  repeated float variance = 6;
+}
+
+message VideoDataParameter{
+  enum VideoType {
+    WEBCAM = 0;
+    VIDEO = 1;
+  }
+  optional VideoType video_type = 1 [default = WEBCAM];
+  optional int32 device_id = 2 [default = 0];
+  optional string video_file = 3;
+}
+

--- a/src/caffe/util/bbox_util.cpp
+++ b/src/caffe/util/bbox_util.cpp
@@ -1,0 +1,1231 @@
+#include <algorithm>
+#include <csignal>
+#include <ctime>
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "boost/iterator/counting_iterator.hpp"
+
+#include "caffe/util/bbox_util.hpp"
+
+namespace caffe {
+
+bool SortBBoxAscend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  return bbox1.score() < bbox2.score();
+}
+
+bool SortBBoxDescend(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  return bbox1.score() > bbox2.score();
+}
+
+template <typename T>
+bool SortScorePairAscend(const pair<float, T>& pair1,
+                         const pair<float, T>& pair2) {
+  return pair1.first < pair2.first;
+}
+
+// Explicit initialization.
+template bool SortScorePairAscend(const pair<float, int>& pair1,
+                                  const pair<float, int>& pair2);
+template bool SortScorePairAscend(const pair<float, pair<int, int> >& pair1,
+                                  const pair<float, pair<int, int> >& pair2);
+
+template <typename T>
+bool SortScorePairDescend(const pair<float, T>& pair1,
+                          const pair<float, T>& pair2) {
+  return pair1.first > pair2.first;
+}
+
+// Explicit initialization.
+template bool SortScorePairDescend(const pair<float, int>& pair1,
+                                   const pair<float, int>& pair2);
+template bool SortScorePairDescend(const pair<float, pair<int, int> >& pair1,
+                                   const pair<float, pair<int, int> >& pair2);
+
+NormalizedBBox UnitBBox() {
+  NormalizedBBox unit_bbox;
+  unit_bbox.set_xmin(0.);
+  unit_bbox.set_ymin(0.);
+  unit_bbox.set_xmax(1.);
+  unit_bbox.set_ymax(1.);
+  return unit_bbox;
+}
+
+void IntersectBBox(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                   NormalizedBBox* intersect_bbox) {
+  if (bbox2.xmin() > bbox1.xmax() || bbox2.xmax() < bbox1.xmin() ||
+      bbox2.ymin() > bbox1.ymax() || bbox2.ymax() < bbox1.ymin()) {
+    // Return [0, 0, 0, 0] if there is no intersection.
+    intersect_bbox->set_xmin(0);
+    intersect_bbox->set_ymin(0);
+    intersect_bbox->set_xmax(0);
+    intersect_bbox->set_ymax(0);
+  } else {
+    intersect_bbox->set_xmin(std::max(bbox1.xmin(), bbox2.xmin()));
+    intersect_bbox->set_ymin(std::max(bbox1.ymin(), bbox2.ymin()));
+    intersect_bbox->set_xmax(std::min(bbox1.xmax(), bbox2.xmax()));
+    intersect_bbox->set_ymax(std::min(bbox1.ymax(), bbox2.ymax()));
+  }
+}
+
+float BBoxSize(const NormalizedBBox& bbox, const bool normalized) {
+  if (bbox.xmax() < bbox.xmin() || bbox.ymax() < bbox.ymin()) {
+    // If bbox is invalid (e.g. xmax < xmin or ymax < ymin), return 0.
+    return 0;
+  } else {
+    if (bbox.has_size()) {
+      return bbox.size();
+    } else {
+      float width = bbox.xmax() - bbox.xmin();
+      float height = bbox.ymax() - bbox.ymin();
+      if (normalized) {
+        return width * height;
+      } else {
+        // If bbox is not within range [0, 1].
+        return (width + 1) * (height + 1);
+      }
+    }
+  }
+}
+
+void ClipBBox(const NormalizedBBox& bbox, NormalizedBBox* clip_bbox) {
+  clip_bbox->set_xmin(std::max(std::min(bbox.xmin(), 1.f), 0.f));
+  clip_bbox->set_ymin(std::max(std::min(bbox.ymin(), 1.f), 0.f));
+  clip_bbox->set_xmax(std::max(std::min(bbox.xmax(), 1.f), 0.f));
+  clip_bbox->set_ymax(std::max(std::min(bbox.ymax(), 1.f), 0.f));
+  clip_bbox->clear_size();
+  clip_bbox->set_size(BBoxSize(*clip_bbox));
+  clip_bbox->set_difficult(bbox.difficult());
+}
+
+void ScaleBBox(const NormalizedBBox& bbox, const int height, const int width,
+               NormalizedBBox* scale_bbox) {
+  scale_bbox->set_xmin(bbox.xmin() * width);
+  scale_bbox->set_ymin(bbox.ymin() * height);
+  scale_bbox->set_xmax(bbox.xmax() * width);
+  scale_bbox->set_ymax(bbox.ymax() * height);
+  scale_bbox->clear_size();
+  bool normalized = !(width > 1 || height > 1);
+  scale_bbox->set_size(BBoxSize(*scale_bbox, normalized));
+  scale_bbox->set_difficult(bbox.difficult());
+}
+
+void LocateBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                NormalizedBBox* loc_bbox) {
+  float src_width = src_bbox.xmax() - src_bbox.xmin();
+  float src_height = src_bbox.ymax() - src_bbox.ymin();
+  loc_bbox->set_xmin(src_bbox.xmin() + bbox.xmin() * src_width);
+  loc_bbox->set_ymin(src_bbox.ymin() + bbox.ymin() * src_height);
+  loc_bbox->set_xmax(src_bbox.xmin() + bbox.xmax() * src_width);
+  loc_bbox->set_ymax(src_bbox.ymin() + bbox.ymax() * src_height);
+  loc_bbox->set_difficult(bbox.difficult());
+}
+
+bool ProjectBBox(const NormalizedBBox& src_bbox, const NormalizedBBox& bbox,
+                 NormalizedBBox* proj_bbox) {
+  if (bbox.xmin() >= src_bbox.xmax() || bbox.xmax() <= src_bbox.xmin() ||
+      bbox.ymin() >= src_bbox.ymax() || bbox.ymax() <= src_bbox.ymin()) {
+    return false;
+  }
+  float src_width = src_bbox.xmax() - src_bbox.xmin();
+  float src_height = src_bbox.ymax() - src_bbox.ymin();
+  proj_bbox->set_xmin((bbox.xmin() - src_bbox.xmin()) / src_width);
+  proj_bbox->set_ymin((bbox.ymin() - src_bbox.ymin()) / src_height);
+  proj_bbox->set_xmax((bbox.xmax() - src_bbox.xmin()) / src_width);
+  proj_bbox->set_ymax((bbox.ymax() - src_bbox.ymin()) / src_height);
+  proj_bbox->set_difficult(bbox.difficult());
+  ClipBBox(*proj_bbox, proj_bbox);
+  if (BBoxSize(*proj_bbox) > 0) {
+    return true;
+  } else {
+    return false;
+  }
+}
+
+float JaccardOverlap(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2,
+                     const bool normalized) {
+  NormalizedBBox intersect_bbox;
+  IntersectBBox(bbox1, bbox2, &intersect_bbox);
+  float intersect_width, intersect_height;
+  if (normalized) {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin();
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin();
+  } else {
+    intersect_width = intersect_bbox.xmax() - intersect_bbox.xmin() + 1;
+    intersect_height = intersect_bbox.ymax() - intersect_bbox.ymin() + 1;
+  }
+  if (intersect_width > 0 && intersect_height > 0) {
+    float intersect_size = intersect_width * intersect_height;
+    float bbox1_size = BBoxSize(bbox1);
+    float bbox2_size = BBoxSize(bbox2);
+    return intersect_size / (bbox1_size + bbox2_size - intersect_size);
+  } else {
+    return 0.;
+  }
+}
+
+float BBoxCoverage(const NormalizedBBox& bbox1, const NormalizedBBox& bbox2) {
+  NormalizedBBox intersect_bbox;
+  IntersectBBox(bbox1, bbox2, &intersect_bbox);
+  float intersect_size = BBoxSize(intersect_bbox);
+  if (intersect_size > 0) {
+    float bbox1_size = BBoxSize(bbox1);
+    return intersect_size / bbox1_size;
+  } else {
+    return 0.;
+  }
+}
+
+bool MeetEmitConstraint(const NormalizedBBox& src_bbox,
+                        const NormalizedBBox& bbox,
+                        const EmitConstraint& emit_constraint) {
+  EmitType emit_type = emit_constraint.emit_type();
+  if (emit_type == EmitConstraint_EmitType_CENTER) {
+    float x_center = (bbox.xmin() + bbox.xmax()) / 2;
+    float y_center = (bbox.ymin() + bbox.ymax()) / 2;
+    if (x_center >= src_bbox.xmin() && x_center <= src_bbox.xmax() &&
+        y_center >= src_bbox.ymin() && y_center <= src_bbox.ymax()) {
+      return true;
+    } else {
+      return false;
+    }
+  } else if (emit_type == EmitConstraint_EmitType_MIN_OVERLAP) {
+    float bbox_coverage = BBoxCoverage(bbox, src_bbox);
+    return bbox_coverage > emit_constraint.emit_overlap();
+  } else {
+    LOG(FATAL) << "Unknown emit type.";
+    return false;
+  }
+}
+
+void EncodeBBox(
+    const NormalizedBBox& prior_bbox, const vector<float>& prior_variance,
+    const CodeType code_type, const bool encode_variance_in_target,
+    const NormalizedBBox& bbox, NormalizedBBox* encode_bbox) {
+  if (code_type == PriorBoxParameter_CodeType_CORNER) {
+    if (encode_variance_in_target) {
+      encode_bbox->set_xmin(bbox.xmin() - prior_bbox.xmin());
+      encode_bbox->set_ymin(bbox.ymin() - prior_bbox.ymin());
+      encode_bbox->set_xmax(bbox.xmax() - prior_bbox.xmax());
+      encode_bbox->set_ymax(bbox.ymax() - prior_bbox.ymax());
+    } else {
+      // Encode variance in bbox.
+      CHECK_EQ(prior_variance.size(), 4);
+      for (int i = 0; i < prior_variance.size(); ++i) {
+        CHECK_GT(prior_variance[i], 0);
+      }
+      encode_bbox->set_xmin(
+          (bbox.xmin() - prior_bbox.xmin()) / prior_variance[0]);
+      encode_bbox->set_ymin(
+          (bbox.ymin() - prior_bbox.ymin()) / prior_variance[1]);
+      encode_bbox->set_xmax(
+          (bbox.xmax() - prior_bbox.xmax()) / prior_variance[2]);
+      encode_bbox->set_ymax(
+          (bbox.ymax() - prior_bbox.ymax()) / prior_variance[3]);
+    }
+  } else if (code_type == PriorBoxParameter_CodeType_CENTER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    float prior_center_x = (prior_bbox.xmin() + prior_bbox.xmax()) / 2.;
+    float prior_center_y = (prior_bbox.ymin() + prior_bbox.ymax()) / 2.;
+
+    float bbox_width = bbox.xmax() - bbox.xmin();
+    CHECK_GT(bbox_width, 0);
+    float bbox_height = bbox.ymax() - bbox.ymin();
+    CHECK_GT(bbox_height, 0);
+    float bbox_center_x = (bbox.xmin() + bbox.xmax()) / 2.;
+    float bbox_center_y = (bbox.ymin() + bbox.ymax()) / 2.;
+
+    if (encode_variance_in_target) {
+      encode_bbox->set_xmin((bbox_center_x - prior_center_x) / prior_width);
+      encode_bbox->set_ymin((bbox_center_y - prior_center_y) / prior_height);
+      encode_bbox->set_xmax(log(bbox_width / prior_width));
+      encode_bbox->set_ymax(log(bbox_height / prior_height));
+    } else {
+      // Encode variance in bbox.
+      encode_bbox->set_xmin(
+          (bbox_center_x - prior_center_x) / prior_width / prior_variance[0]);
+      encode_bbox->set_ymin(
+          (bbox_center_y - prior_center_y) / prior_height / prior_variance[1]);
+      encode_bbox->set_xmax(
+          log(bbox_width / prior_width) / prior_variance[2]);
+      encode_bbox->set_ymax(
+          log(bbox_height / prior_height) / prior_variance[3]);
+    }
+  } else {
+    LOG(FATAL) << "Unknown LocLossType.";
+  }
+}
+
+void DecodeBBox(
+    const NormalizedBBox& prior_bbox, const vector<float>& prior_variance,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const NormalizedBBox& bbox, NormalizedBBox* decode_bbox) {
+  if (code_type == PriorBoxParameter_CodeType_CORNER) {
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to add the offset
+      // predictions.
+      decode_bbox->set_xmin(prior_bbox.xmin() + bbox.xmin());
+      decode_bbox->set_ymin(prior_bbox.ymin() + bbox.ymin());
+      decode_bbox->set_xmax(prior_bbox.xmax() + bbox.xmax());
+      decode_bbox->set_ymax(prior_bbox.ymax() + bbox.ymax());
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox->set_xmin(
+          prior_bbox.xmin() + prior_variance[0] * bbox.xmin());
+      decode_bbox->set_ymin(
+          prior_bbox.ymin() + prior_variance[1] * bbox.ymin());
+      decode_bbox->set_xmax(
+          prior_bbox.xmax() + prior_variance[2] * bbox.xmax());
+      decode_bbox->set_ymax(
+          prior_bbox.ymax() + prior_variance[3] * bbox.ymax());
+    }
+  } else if (code_type == PriorBoxParameter_CodeType_CENTER_SIZE) {
+    float prior_width = prior_bbox.xmax() - prior_bbox.xmin();
+    CHECK_GT(prior_width, 0);
+    float prior_height = prior_bbox.ymax() - prior_bbox.ymin();
+    CHECK_GT(prior_height, 0);
+    float prior_center_x = (prior_bbox.xmin() + prior_bbox.xmax()) / 2.;
+    float prior_center_y = (prior_bbox.ymin() + prior_bbox.ymax()) / 2.;
+
+    float decode_bbox_center_x, decode_bbox_center_y;
+    float decode_bbox_width, decode_bbox_height;
+    if (variance_encoded_in_target) {
+      // variance is encoded in target, we simply need to retore the offset
+      // predictions.
+      decode_bbox_center_x = bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y = bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width = exp(bbox.xmax()) * prior_width;
+      decode_bbox_height = exp(bbox.ymax()) * prior_height;
+    } else {
+      // variance is encoded in bbox, we need to scale the offset accordingly.
+      decode_bbox_center_x =
+          prior_variance[0] * bbox.xmin() * prior_width + prior_center_x;
+      decode_bbox_center_y =
+          prior_variance[1] * bbox.ymin() * prior_height + prior_center_y;
+      decode_bbox_width =
+          exp(prior_variance[2] * bbox.xmax()) * prior_width;
+      decode_bbox_height =
+          exp(prior_variance[3] * bbox.ymax()) * prior_height;
+    }
+
+    decode_bbox->set_xmin(decode_bbox_center_x - decode_bbox_width / 2.);
+    decode_bbox->set_ymin(decode_bbox_center_y - decode_bbox_height / 2.);
+    decode_bbox->set_xmax(decode_bbox_center_x + decode_bbox_width / 2.);
+    decode_bbox->set_ymax(decode_bbox_center_y + decode_bbox_height / 2.);
+  } else {
+    LOG(FATAL) << "Unknown LocLossType.";
+  }
+  float bbox_size = BBoxSize(*decode_bbox);
+  decode_bbox->set_size(bbox_size);
+}
+
+void DecodeBBoxes(
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    const vector<NormalizedBBox>& bboxes,
+    vector<NormalizedBBox>* decode_bboxes) {
+  CHECK_EQ(prior_bboxes.size(), prior_variances.size());
+  CHECK_EQ(prior_bboxes.size(), bboxes.size());
+  int num_bboxes = prior_bboxes.size();
+  if (num_bboxes >= 1) {
+    CHECK_EQ(prior_variances[0].size(), 4);
+  }
+  decode_bboxes->clear();
+  for (int i = 0; i < num_bboxes; ++i) {
+    NormalizedBBox decode_bbox;
+    DecodeBBox(prior_bboxes[i], prior_variances[i], code_type,
+               variance_encoded_in_target, bboxes[i], &decode_bbox);
+    decode_bboxes->push_back(decode_bbox);
+  }
+}
+
+void DecodeBBoxesAll(const vector<LabelBBox>& all_loc_preds,
+    const vector<NormalizedBBox>& prior_bboxes,
+    const vector<vector<float> >& prior_variances,
+    const int num, const bool share_location,
+    const int num_loc_classes, const int background_label_id,
+    const CodeType code_type, const bool variance_encoded_in_target,
+    vector<LabelBBox>* all_decode_bboxes) {
+  CHECK_EQ(all_loc_preds.size(), num);
+  all_decode_bboxes->clear();
+  all_decode_bboxes->resize(num);
+  for (int i = 0; i < num; ++i) {
+    // Decode predictions into bboxes.
+    LabelBBox& decode_bboxes = (*all_decode_bboxes)[i];
+    for (int c = 0; c < num_loc_classes; ++c) {
+      int label = share_location ? -1 : c;
+      if (label == background_label_id) {
+        // Ignore background class.
+        continue;
+      }
+      if (all_loc_preds[i].find(label) == all_loc_preds[i].end()) {
+        // Something bad happened if there are no predictions for current label.
+        LOG(FATAL) << "Could not find location predictions for label " << label;
+      }
+      const vector<NormalizedBBox>& label_loc_preds =
+          all_loc_preds[i].find(label)->second;
+      DecodeBBoxes(prior_bboxes, prior_variances,
+                   code_type, variance_encoded_in_target,
+                   label_loc_preds, &(decode_bboxes[label]));
+    }
+  }
+}
+
+void MatchBBox(const vector<NormalizedBBox>& gt_bboxes,
+    const vector<NormalizedBBox>& pred_bboxes, const int label,
+    const MatchType match_type, const float overlap_threshold,
+    vector<int>* match_indices, vector<float>* match_overlaps) {
+  int num_pred = pred_bboxes.size();
+  match_indices->clear();
+  match_indices->resize(num_pred, -1);
+  match_overlaps->clear();
+  match_overlaps->resize(num_pred, 0.);
+
+  int num_gt = 0;
+  vector<int> gt_indices;
+  if (label == -1) {
+    // label -1 means comparing against all ground truth.
+    num_gt = gt_bboxes.size();
+    for (int i = 0; i < num_gt; ++i) {
+      gt_indices.push_back(i);
+    }
+  } else {
+    // Count number of ground truth boxes which has the desired label.
+    for (int i = 0; i < gt_bboxes.size(); ++i) {
+      if (gt_bboxes[i].label() == label) {
+        num_gt++;
+        gt_indices.push_back(i);
+      }
+    }
+  }
+  if (num_gt == 0) {
+    return;
+  }
+
+  // Store the positive overlap between predictions and ground truth.
+  map<int, map<int, float> > overlaps;
+  for (int i = 0; i < num_pred; ++i) {
+    for (int j = 0; j < num_gt; ++j) {
+      float overlap = JaccardOverlap(pred_bboxes[i], gt_bboxes[gt_indices[j]]);
+      if (overlap > 1e-6) {
+        (*match_overlaps)[i] = std::max((*match_overlaps)[i], overlap);
+        overlaps[i][j] = overlap;
+      }
+    }
+  }
+
+  // Bipartite matching.
+  vector<int> gt_pool;
+  for (int i = 0; i < num_gt; ++i) {
+    gt_pool.push_back(i);
+  }
+  while (gt_pool.size() > 0) {
+    // Find the most overlapped gt and cooresponding predictions.
+    int max_idx = -1;
+    int max_gt_idx = -1;
+    float max_overlap = -1;
+    for (map<int, map<int, float> >::iterator it = overlaps.begin();
+         it != overlaps.end(); ++it) {
+      int i = it->first;
+      if ((*match_indices)[i] != -1) {
+        // The prediction already have matched ground truth.
+        continue;
+      }
+      for (int p = 0; p < gt_pool.size(); ++p) {
+        int j = gt_pool[p];
+        if (it->second.find(j) == it->second.end()) {
+          // No overlap between the i-th prediction and j-th ground truth.
+          continue;
+        }
+        // Find the maximum overlapped pair.
+        if (it->second[j] > max_overlap) {
+          // If the prediction has not been matched to any ground truth,
+          // and the overlap is larger than maximum overlap, update.
+          max_idx = i;
+          max_gt_idx = j;
+          max_overlap = it->second[j];
+        }
+      }
+    }
+    if (max_idx == -1) {
+      // Cannot find good match.
+      break;
+    } else {
+      CHECK_EQ((*match_indices)[max_idx], -1);
+      (*match_indices)[max_idx] = gt_indices[max_gt_idx];
+      (*match_overlaps)[max_idx] = max_overlap;
+      // Erase the ground truth.
+      gt_pool.erase(std::find(gt_pool.begin(), gt_pool.end(), max_gt_idx));
+    }
+  }
+
+  switch (match_type) {
+    case MultiBoxLossParameter_MatchType_BIPARTITE:
+      // Already done.
+      break;
+    case MultiBoxLossParameter_MatchType_PER_PREDICTION:
+      // Get most overlaped for the rest prediction bboxes.
+      for (map<int, map<int, float> >::iterator it = overlaps.begin();
+           it != overlaps.end(); ++it) {
+        int i = it->first;
+        if ((*match_indices)[i] != -1) {
+          // The prediction already have matched ground truth.
+          continue;
+        }
+        int max_gt_idx = -1;
+        float max_overlap = -1;
+        for (int j = 0; j < num_gt; ++j) {
+          if (it->second.find(j) == it->second.end()) {
+            // No overlap between the i-th prediction and j-th ground truth.
+            continue;
+          }
+          // Find the maximum overlapped pair.
+          float overlap = it->second[j];
+          if (overlap >= overlap_threshold && overlap > max_overlap) {
+            // If the prediction has not been matched to any ground truth,
+            // and the overlap is larger than maximum overlap, update.
+            max_gt_idx = j;
+            max_overlap = overlap;
+          }
+        }
+        if (max_gt_idx != -1) {
+          // Found a matched ground truth.
+          CHECK_EQ((*match_indices)[i], -1);
+          (*match_indices)[i] = gt_indices[max_gt_idx];
+          (*match_overlaps)[i] = max_overlap;
+        }
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown matching type.";
+      break;
+  }
+
+  return;
+}
+
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes) {
+  all_gt_bboxes->clear();
+  for (int i = 0; i < num_gt; ++i) {
+    int start_idx = i * 8;
+    int item_id = gt_data[start_idx];
+    if (item_id == -1) {
+      continue;
+    }
+    int label = gt_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the dataset.";
+    bool difficult = static_cast<bool>(gt_data[start_idx + 7]);
+    if (!use_difficult_gt && difficult) {
+      // Skip reading difficult ground truth.
+      continue;
+    }
+    NormalizedBBox bbox;
+    bbox.set_label(label);
+    bbox.set_xmin(gt_data[start_idx + 3]);
+    bbox.set_ymin(gt_data[start_idx + 4]);
+    bbox.set_xmax(gt_data[start_idx + 5]);
+    bbox.set_ymax(gt_data[start_idx + 6]);
+    bbox.set_difficult(difficult);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_gt_bboxes)[item_id].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetGroundTruth(const float* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+template void GetGroundTruth(const double* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, vector<NormalizedBBox> >* all_gt_bboxes);
+
+template <typename Dtype>
+void GetGroundTruth(const Dtype* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes) {
+  all_gt_bboxes->clear();
+  for (int i = 0; i < num_gt; ++i) {
+    int start_idx = i * 8;
+    int item_id = gt_data[start_idx];
+    if (item_id == -1) {
+      break;
+    }
+    NormalizedBBox bbox;
+    int label = gt_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the dataset.";
+    bool difficult = static_cast<bool>(gt_data[start_idx + 7]);
+    if (!use_difficult_gt && difficult) {
+      // Skip reading difficult ground truth.
+      continue;
+    }
+    bbox.set_xmin(gt_data[start_idx + 3]);
+    bbox.set_ymin(gt_data[start_idx + 4]);
+    bbox.set_xmax(gt_data[start_idx + 5]);
+    bbox.set_ymax(gt_data[start_idx + 6]);
+    bbox.set_difficult(difficult);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_gt_bboxes)[item_id][label].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetGroundTruth(const float* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+template void GetGroundTruth(const double* gt_data, const int num_gt,
+      const int background_label_id, const bool use_difficult_gt,
+      map<int, LabelBBox>* all_gt_bboxes);
+
+template <typename Dtype>
+void GetLocPredictions(const Dtype* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds) {
+  loc_preds->clear();
+  if (share_location) {
+    CHECK_EQ(num_loc_classes, 1);
+  }
+  loc_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    LabelBBox& label_bbox = (*loc_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_loc_classes * 4;
+      for (int c = 0; c < num_loc_classes; ++c) {
+        int label = share_location ? -1 : c;
+        if (label_bbox.find(label) == label_bbox.end()) {
+          label_bbox[label].resize(num_preds_per_class);
+        }
+        label_bbox[label][p].set_xmin(loc_data[start_idx + c * 4]);
+        label_bbox[label][p].set_ymin(loc_data[start_idx + c * 4 + 1]);
+        label_bbox[label][p].set_xmax(loc_data[start_idx + c * 4 + 2]);
+        label_bbox[label][p].set_ymax(loc_data[start_idx + c * 4 + 3]);
+      }
+    }
+    loc_data += num_preds_per_class * num_loc_classes * 4;
+  }
+}
+
+// Explicit initialization.
+template void GetLocPredictions(const float* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+template void GetLocPredictions(const double* loc_data, const int num,
+      const int num_preds_per_class, const int num_loc_classes,
+      const bool share_location, vector<LabelBBox>* loc_preds);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds) {
+  conf_preds->clear();
+  conf_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<float> >& label_scores = (*conf_preds)[i];
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      for (int c = 0; c < num_classes; ++c) {
+        label_scores[c].push_back(conf_data[start_idx + c]);
+      }
+    }
+    conf_data += num_preds_per_class * num_classes;
+  }
+}
+
+// Explicit initialization.
+template void GetConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      vector<map<int, vector<float> > >* conf_preds);
+
+template <typename Dtype>
+void GetConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds) {
+  conf_preds->clear();
+  conf_preds->resize(num);
+  for (int i = 0; i < num; ++i) {
+    map<int, vector<float> >& label_scores = (*conf_preds)[i];
+    if (class_major) {
+      for (int c = 0; c < num_classes; ++c) {
+        label_scores[c].assign(conf_data, conf_data + num_preds_per_class);
+        conf_data += num_preds_per_class;
+      }
+    } else {
+      for (int p = 0; p < num_preds_per_class; ++p) {
+        int start_idx = p * num_classes;
+        for (int c = 0; c < num_classes; ++c) {
+          label_scores[c].push_back(conf_data[start_idx + c]);
+        }
+      }
+      conf_data += num_preds_per_class * num_classes;
+    }
+  }
+}
+
+// Explicit initialization.
+template void GetConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+template void GetConfidenceScores(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const bool class_major, vector<map<int, vector<float> > >* conf_preds);
+
+template <typename Dtype>
+void GetMaxConfidenceScores(const Dtype* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_max_scores) {
+  all_max_scores->clear();
+  for (int i = 0; i < num; ++i) {
+    vector<float> max_scores;
+    for (int p = 0; p < num_preds_per_class; ++p) {
+      int start_idx = p * num_classes;
+      Dtype maxval = -FLT_MAX;
+      Dtype maxval_pos = -FLT_MAX;
+      for (int c = 0; c < num_classes; ++c) {
+        maxval = std::max<Dtype>(conf_data[start_idx + c], maxval);
+        if (c != background_label_id) {
+          // Find maximum scores for positive classes.
+          maxval_pos = std::max<Dtype>(conf_data[start_idx + c], maxval_pos);
+        }
+      }
+      if (loss_type == MultiBoxLossParameter_ConfLossType_SOFTMAX) {
+        // Compute softmax probability.
+        Dtype sum = 0.;
+        for (int c = 0; c < num_classes; ++c) {
+          sum += std::exp(conf_data[start_idx + c] - maxval);
+        }
+        maxval_pos = std::exp(maxval_pos - maxval) / sum;
+      } else if (loss_type == MultiBoxLossParameter_ConfLossType_LOGISTIC) {
+        maxval_pos = 1. / (1. + exp(-maxval_pos));
+      } else {
+        LOG(FATAL) << "Unknown conf loss type.";
+      }
+      max_scores.push_back(maxval_pos);
+    }
+    conf_data += num_preds_per_class * num_classes;
+    all_max_scores->push_back(max_scores);
+  }
+}
+
+// Explicit initialization.
+template void GetMaxConfidenceScores(const float* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_max_scores);
+template void GetMaxConfidenceScores(const double* conf_data, const int num,
+      const int num_preds_per_class, const int num_classes,
+      const int background_label_id, const ConfLossType loss_type,
+      vector<vector<float> >* all_max_scores);
+
+template <typename Dtype>
+void GetPriorBBoxes(const Dtype* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances) {
+  prior_bboxes->clear();
+  prior_variances->clear();
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = i * 4;
+    NormalizedBBox bbox;
+    bbox.set_xmin(prior_data[start_idx]);
+    bbox.set_ymin(prior_data[start_idx + 1]);
+    bbox.set_xmax(prior_data[start_idx + 2]);
+    bbox.set_ymax(prior_data[start_idx + 3]);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    prior_bboxes->push_back(bbox);
+  }
+
+  for (int i = 0; i < num_priors; ++i) {
+    int start_idx = (num_priors + i) * 4;
+    vector<float> var;
+    for (int j = 0; j < 4; ++j) {
+      var.push_back(prior_data[start_idx + j]);
+    }
+    prior_variances->push_back(var);
+  }
+}
+
+// Explicit initialization.
+template void GetPriorBBoxes(const float* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+template void GetPriorBBoxes(const double* prior_data, const int num_priors,
+      vector<NormalizedBBox>* prior_bboxes,
+      vector<vector<float> >* prior_variances);
+
+template <typename Dtype>
+void GetDetectionResults(const Dtype* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections) {
+  all_detections->clear();
+  for (int i = 0; i < num_det; ++i) {
+    int start_idx = i * 7;
+    int item_id = det_data[start_idx];
+    if (item_id == -1) {
+      continue;
+    }
+    int label = det_data[start_idx + 1];
+    CHECK_NE(background_label_id, label)
+        << "Found background label in the detection results.";
+    NormalizedBBox bbox;
+    bbox.set_score(det_data[start_idx + 2]);
+    bbox.set_xmin(det_data[start_idx + 3]);
+    bbox.set_ymin(det_data[start_idx + 4]);
+    bbox.set_xmax(det_data[start_idx + 5]);
+    bbox.set_ymax(det_data[start_idx + 6]);
+    float bbox_size = BBoxSize(bbox);
+    bbox.set_size(bbox_size);
+    (*all_detections)[item_id][label].push_back(bbox);
+  }
+}
+
+// Explicit initialization.
+template void GetDetectionResults(const float* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+template void GetDetectionResults(const double* det_data, const int num_det,
+      const int background_label_id,
+      map<int, map<int, vector<NormalizedBBox> > >* all_detections);
+
+void GetTopKScoreIndex(const vector<float>& scores, const vector<int>& indices,
+      const int top_k, vector<pair<float, int> >* score_index_vec) {
+  CHECK_EQ(scores.size(), indices.size());
+
+  // Generate index score pairs.
+  for (int i = 0; i < scores.size(); ++i) {
+    score_index_vec->push_back(std::make_pair(scores[i], indices[i]));
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::stable_sort(score_index_vec->begin(), score_index_vec->end(),
+                   SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+void ApplyNMS(const vector<NormalizedBBox>& bboxes, const vector<float>& scores,
+      const float threshold, const int top_k, const bool reuse_overlaps,
+      map<int, map<int, float> >* overlaps, vector<int>* indices) {
+  // Sanity check.
+  CHECK_EQ(bboxes.size(), scores.size())
+      << "bboxes and scores have different size.";
+
+  // Get top_k scores (with corresponding indices).
+  vector<int> idx(boost::counting_iterator<int>(0),
+                  boost::counting_iterator<int>(scores.size()));
+  vector<pair<float, int> > score_index_vec;
+  GetTopKScoreIndex(scores, idx, top_k, &score_index_vec);
+
+  // Do nms.
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    // Get the current highest score box.
+    int best_idx = score_index_vec.front().second;
+    const NormalizedBBox& best_bbox = bboxes[best_idx];
+    if (BBoxSize(best_bbox) < 1e-5) {
+      // Erase small box.
+      score_index_vec.erase(score_index_vec.begin());
+      continue;
+    }
+    indices->push_back(best_idx);
+    // Erase the best box.
+    score_index_vec.erase(score_index_vec.begin());
+
+    if (top_k > -1 && indices->size() >= top_k) {
+      // Stop if finding enough bboxes for nms.
+      break;
+    }
+
+    // Compute overlap between best_bbox and other remaining bboxes.
+    // Remove a bbox if the overlap with best_bbox is larger than nms_threshold.
+    for (vector<pair<float, int> >::iterator it = score_index_vec.begin();
+         it != score_index_vec.end(); ) {
+      int cur_idx = it->second;
+      const NormalizedBBox& cur_bbox = bboxes[cur_idx];
+      if (BBoxSize(cur_bbox) < 1e-5) {
+        // Erase small box.
+        it = score_index_vec.erase(it);
+        continue;
+      }
+      float cur_overlap = 0.;
+      if (reuse_overlaps) {
+        if (overlaps->find(best_idx) != overlaps->end() &&
+            overlaps->find(best_idx)->second.find(cur_idx) !=
+            (*overlaps)[best_idx].end()) {
+          // Use the computed overlap.
+          cur_overlap = (*overlaps)[best_idx][cur_idx];
+        } else if (overlaps->find(cur_idx) != overlaps->end() &&
+                   overlaps->find(cur_idx)->second.find(best_idx) !=
+                   (*overlaps)[cur_idx].end()) {
+          // Use the computed overlap.
+          cur_overlap = (*overlaps)[cur_idx][best_idx];
+        } else {
+          cur_overlap = JaccardOverlap(best_bbox, cur_bbox);
+          // Store the overlap for future use.
+          (*overlaps)[best_idx][cur_idx] = cur_overlap;
+        }
+      } else {
+        cur_overlap = JaccardOverlap(best_bbox, cur_bbox);
+      }
+
+      // Remove it if necessary
+      if (cur_overlap > threshold) {
+        it = score_index_vec.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+void ApplyNMS(const bool* overlapped, const int num, vector<int>* indices) {
+  vector<int> index_vec(boost::counting_iterator<int>(0),
+                        boost::counting_iterator<int>(num));
+  // Do nms.
+  indices->clear();
+  while (index_vec.size() != 0) {
+    // Get the current highest score box.
+    int best_idx = index_vec.front();
+    indices->push_back(best_idx);
+    // Erase the best box.
+    index_vec.erase(index_vec.begin());
+
+    for (vector<int>::iterator it = index_vec.begin(); it != index_vec.end();) {
+      int cur_idx = *it;
+
+      // Remove it if necessary
+      if (overlapped[best_idx * num + cur_idx]) {
+        it = index_vec.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+}
+
+void GetMaxScoreIndex(const vector<float>& scores, const float threshold,
+      const int top_k, vector<pair<float, int> >* score_index_vec) {
+  // Generate index score pairs.
+  for (int i = 0; i < scores.size(); ++i) {
+    if (scores[i] > threshold) {
+      score_index_vec->push_back(std::make_pair(scores[i], i));
+    }
+  }
+
+  // Sort the score pair according to the scores in descending order
+  std::stable_sort(score_index_vec->begin(), score_index_vec->end(),
+                   SortScorePairDescend<int>);
+
+  // Keep top_k scores if needed.
+  if (top_k > -1 && top_k < score_index_vec->size()) {
+    score_index_vec->resize(top_k);
+  }
+}
+
+void ApplyNMSFast(const vector<NormalizedBBox>& bboxes,
+      const vector<float>& scores, const float score_threshold,
+      const float nms_threshold, const int top_k, vector<int>* indices) {
+  // Sanity check.
+  CHECK_EQ(bboxes.size(), scores.size())
+      << "bboxes and scores have different size.";
+
+  // Get top_k scores (with corresponding indices).
+  vector<pair<float, int> > score_index_vec;
+  GetMaxScoreIndex(scores, score_threshold, top_k, &score_index_vec);
+
+  // Do nms.
+  indices->clear();
+  while (score_index_vec.size() != 0) {
+    const int idx = score_index_vec.front().second;
+    bool keep = true;
+    for (int k = 0; k < indices->size(); ++k) {
+      if (keep) {
+        const int kept_idx = (*indices)[k];
+        float overlap = JaccardOverlap(bboxes[idx], bboxes[kept_idx]);
+        keep = overlap <= nms_threshold;
+      } else {
+        break;
+      }
+    }
+    if (keep) {
+      indices->push_back(idx);
+    }
+    score_index_vec.erase(score_index_vec.begin());
+  }
+}
+
+void CumSum(const vector<pair<float, int> >& pairs, vector<int>* cumsum) {
+  // Sort the pairs based on first item of the pair.
+  vector<pair<float, int> > sort_pairs = pairs;
+  std::stable_sort(sort_pairs.begin(), sort_pairs.end(),
+                   SortScorePairDescend<int>);
+
+  cumsum->clear();
+  for (int i = 0; i < sort_pairs.size(); ++i) {
+    if (i == 0) {
+      cumsum->push_back(sort_pairs[i].second);
+    } else {
+      cumsum->push_back(cumsum->back() + sort_pairs[i].second);
+    }
+  }
+}
+
+void ComputeAP(const vector<pair<float, int> >& tp, const int num_pos,
+               const vector<pair<float, int> >& fp, const string ap_version,
+               vector<float>* prec, vector<float>* rec, float* ap) {
+  const float eps = 1e-6;
+  CHECK_EQ(tp.size(), fp.size()) << "tp must have same size as fp.";
+  const int num = tp.size();
+  // Make sure that tp and fp have complement value.
+  for (int i = 0; i < num; ++i) {
+    CHECK_LE(fabs(tp[i].first - fp[i].first), eps);
+    CHECK_EQ(tp[i].second, 1 - fp[i].second);
+  }
+  prec->clear();
+  rec->clear();
+  *ap = 0;
+  if (tp.size() == 0 || num_pos == 0) {
+    return;
+  }
+
+  // Compute cumsum of tp.
+  vector<int> tp_cumsum;
+  CumSum(tp, &tp_cumsum);
+  CHECK_EQ(tp_cumsum.size(), num);
+
+  // Compute cumsum of fp.
+  vector<int> fp_cumsum;
+  CumSum(fp, &fp_cumsum);
+  CHECK_EQ(fp_cumsum.size(), num);
+
+  // Compute precision.
+  for (int i = 0; i < num; ++i) {
+    prec->push_back(static_cast<float>(tp_cumsum[i]) /
+                    (tp_cumsum[i] + fp_cumsum[i]));
+  }
+
+  // Compute recall.
+  for (int i = 0; i < num; ++i) {
+    CHECK_LE(tp_cumsum[i], num_pos);
+    rec->push_back(static_cast<float>(tp_cumsum[i]) / num_pos);
+  }
+
+  if (ap_version == "11point") {
+    // VOC2007 style for computing AP.
+    vector<float> max_precs(11, 0.);
+    int start_idx = num - 1;
+    for (int j = 10; j >= 0; --j) {
+      for (int i = start_idx; i >= 0 ; --i) {
+        if ((*rec)[i] < j / 10.) {
+          start_idx = i;
+          if (j > 0) {
+            max_precs[j-1] = max_precs[j];
+          }
+          break;
+        } else {
+          if (max_precs[j] < (*prec)[i]) {
+            max_precs[j] = (*prec)[i];
+          }
+        }
+      }
+    }
+    for (int j = 10; j >= 0; --j) {
+      *ap += max_precs[j] / 11;
+    }
+  } else if (ap_version == "MaxIntegral") {
+    // VOC2012 or ILSVRC style for computing AP.
+    float cur_rec = rec->back();
+    float cur_prec = prec->back();
+    for (int i = num - 2; i >= 0; --i) {
+      cur_prec = std::max<float>((*prec)[i], cur_prec);
+      if (fabs(cur_rec - (*rec)[i]) > eps) {
+        *ap += cur_prec * fabs(cur_rec - (*rec)[i]);
+      }
+      cur_rec = (*rec)[i];
+    }
+    *ap += cur_rec * cur_prec;
+  } else if (ap_version == "Integral") {
+    // Natural integral.
+    float prev_rec = 0.;
+    for (int i = 0; i < num; ++i) {
+      if (fabs((*rec)[i] - prev_rec) > eps) {
+        *ap += (*prec)[i] * fabs((*rec)[i] - prev_rec);
+      }
+      prev_rec = (*rec)[i];
+    }
+  } else {
+    LOG(FATAL) << "Unknown ap_version: " << ap_version;
+  }
+}
+
+#ifdef USE_OPENCV
+cv::Scalar HSV2RGB(const float h, const float s, const float v) {
+  const int h_i = static_cast<int>(h * 6);
+  const float f = h * 6 - h_i;
+  const float p = v * (1 - s);
+  const float q = v * (1 - f*s);
+  const float t = v * (1 - (1 - f) * s);
+  float r, g, b;
+  switch (h_i) {
+    case 0:
+      r = v; g = t; b = p;
+      break;
+    case 1:
+      r = q; g = v; b = p;
+      break;
+    case 2:
+      r = p; g = v; b = t;
+      break;
+    case 3:
+      r = p; g = q; b = v;
+      break;
+    case 4:
+      r = t; g = p; b = v;
+      break;
+    case 5:
+      r = v; g = p; b = q;
+      break;
+    default:
+      r = 1; g = 1; b = 1;
+      break;
+  }
+  return cv::Scalar(r * 255, g * 255, b * 255);
+}
+
+// http://martin.ankerl.com/2009/12/09/how-to-create-random-colors-programmatically
+vector<cv::Scalar> GetColors(const int n) {
+  vector<cv::Scalar> colors;
+  cv::RNG rng(12345);
+  const float golden_ratio_conjugate = 0.618033988749895;
+  const float s = 0.3;
+  const float v = 0.99;
+  for (int i = 0; i < n; ++i) {
+    const float h = std::fmod(rng.uniform(0.f, 1.f) + golden_ratio_conjugate,
+                              1.f);
+    colors.push_back(HSV2RGB(h, s, v));
+  }
+  return colors;
+}
+
+static clock_t start_clock = clock();
+
+template <typename Dtype>
+void VisualizeBBox(const vector<cv::Mat>& images, const Blob<Dtype>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name) {
+  // Retrieve detections.
+  CHECK_EQ(detections->width(), 7);
+  const int num_det = detections->height();
+  const int num_img = images.size();
+  if (num_det == 0 || num_img == 0) {
+    return;
+  }
+  // Comute FPS.
+  float fps = num_img / (static_cast<double>(clock() - start_clock) /
+          CLOCKS_PER_SEC);
+
+  const Dtype* detections_data = detections->cpu_data();
+  const int width = images[0].cols;
+  const int height = images[0].rows;
+  vector<LabelBBox> all_detections(num_img);
+  for (int i = 0; i < num_det; ++i) {
+    const int img_idx = detections_data[i * 7];
+    CHECK_LT(img_idx, num_img);
+    const int label = detections_data[i * 7 + 1];
+    const float score = detections_data[i * 7 + 2];
+    if (score < threshold) {
+      continue;
+    }
+    NormalizedBBox bbox;
+    bbox.set_xmin(detections_data[i * 7 + 3] * width);
+    bbox.set_ymin(detections_data[i * 7 + 4] * height);
+    bbox.set_xmax(detections_data[i * 7 + 5] * width);
+    bbox.set_ymax(detections_data[i * 7 + 6] * height);
+    bbox.set_score(score);
+    all_detections[img_idx][label].push_back(bbox);
+  }
+
+  int fontface = cv::FONT_HERSHEY_SIMPLEX;
+  double scale = 1;
+  int thickness = 2;
+  int baseline = 0;
+  char buffer[50];
+  for (int i = 0; i < num_img; ++i) {
+    cv::Mat image = images[i];
+    // Show FPS.
+    snprintf(buffer, sizeof(buffer), "FPS: %.2f", fps);
+    cv::Size text = cv::getTextSize(buffer, fontface, scale, thickness,
+                                    &baseline);
+    cv::rectangle(image, cv::Point(0, 0),
+                  cv::Point(text.width, text.height + baseline),
+                  CV_RGB(255, 255, 255), CV_FILLED);
+    cv::putText(image, buffer, cv::Point(0, text.height + baseline / 2.),
+                fontface, scale, CV_RGB(0, 0, 0), thickness, 8);
+    // Draw bboxes.
+    for (map<int, vector<NormalizedBBox> >::iterator it =
+         all_detections[i].begin(); it != all_detections[i].end(); ++it) {
+      int label = it->first;
+      string label_name = "Unknown";
+      if (label_to_display_name.find(label) != label_to_display_name.end()) {
+        label_name = label_to_display_name.find(label)->second;
+      }
+      CHECK_LT(label, colors.size());
+      const cv::Scalar& color = colors[label];
+      const vector<NormalizedBBox>& bboxes = it->second;
+      for (int j = 0; j < bboxes.size(); ++j) {
+        cv::Point top_left_pt(bboxes[j].xmin(), bboxes[j].ymin());
+        cv::Point bottom_right_pt(bboxes[j].xmax(), bboxes[j].ymax());
+        cv::rectangle(image, top_left_pt, bottom_right_pt, color, 4);
+        cv::Point bottom_left_pt(bboxes[j].xmin(), bboxes[j].ymax());
+        snprintf(buffer, sizeof(buffer), "%s: %.2f", label_name.c_str(),
+                 bboxes[j].score());
+        cv::Size text = cv::getTextSize(buffer, fontface, scale, thickness,
+                                        &baseline);
+        cv::rectangle(
+            image, bottom_left_pt + cv::Point(0, 0),
+            bottom_left_pt + cv::Point(text.width, -text.height-baseline),
+            color, CV_FILLED);
+        cv::putText(image, buffer, bottom_left_pt - cv::Point(0, baseline),
+                    fontface, scale, CV_RGB(0, 0, 0), thickness, 8);
+      }
+    }
+    cv::imshow("detections", image);
+    if (cv::waitKey(1) == 27) {
+      raise(SIGINT);
+    }
+  }
+  start_clock = clock();
+}
+
+template
+void VisualizeBBox(const vector<cv::Mat>& images,
+                   const Blob<float>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name);
+template
+void VisualizeBBox(const vector<cv::Mat>& images,
+                   const Blob<double>* detections,
+                   const float threshold, const vector<cv::Scalar>& colors,
+                   const map<int, string>& label_to_display_name);
+
+#endif  // USE_OPENCV
+
+}  // namespace caffe

--- a/src/caffe/util/blocking_queue.cpp
+++ b/src/caffe/util/blocking_queue.cpp
@@ -1,40 +1,3 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
 #include <boost/thread.hpp>
 #include <string>
 
@@ -125,10 +88,13 @@ size_t BlockingQueue<T>::size() const {
 
 template class BlockingQueue<Batch<float>*>;
 template class BlockingQueue<Batch<double>*>;
-template class BlockingQueue<std::string*>;
-template class BlockingQueue<shared_ptr<DataReader::QueuePair> >;
+template class BlockingQueue<Datum*>;
+template class BlockingQueue<Element*>;
+template class BlockingQueue<AnnotatedDatum*>;
+template class BlockingQueue<shared_ptr<DataReader<Datum>::QueuePair> >;
+template class BlockingQueue<
+  shared_ptr<DataReader<AnnotatedDatum>::QueuePair> >;
 template class BlockingQueue<P2PSync<float>*>;
 template class BlockingQueue<P2PSync<double>*>;
-template class BlockingQueue<Element*>;
 
 }  // namespace caffe

--- a/src/caffe/util/im_transforms.cpp
+++ b/src/caffe/util/im_transforms.cpp
@@ -1,0 +1,524 @@
+#ifdef USE_OPENCV
+#include <opencv2/highgui/highgui.hpp>
+
+#if CV_VERSION_MAJOR == 3
+#include <opencv2/imgcodecs/imgcodecs.hpp>
+#define CV_GRAY2BGR cv::COLOR_GRAY2BGR
+#define CV_BGR2GRAY cv::COLOR_BGR2GRAY
+#define CV_BGR2YCrCb cv::COLOR_BGR2YCrCb
+#define CV_YCrCb2BGR cv::COLOR_YCrCb2BGR
+#define CV_IMWRITE_JPEG_QUALITY cv::IMWRITE_JPEG_QUALITY
+#define CV_LOAD_IMAGE_COLOR cv::IMREAD_COLOR
+#define CV_THRESH_BINARY_INV cv::THRESH_BINARY_INV
+#define CV_THRESH_OTSU cv::THRESH_OTSU
+#endif
+
+#include <algorithm>
+#include <numeric>
+#include <vector>
+
+#include "caffe/util/im_transforms.hpp"
+#include "caffe/util/math_functions.hpp"
+
+namespace caffe {
+
+const float prob_eps = 0.01;
+
+int roll_weighted_die(const vector<float>& probabilities) {
+  vector<float> cumulative;
+  std::partial_sum(&probabilities[0], &probabilities[0] + probabilities.size(),
+                   std::back_inserter(cumulative));
+  float val;
+  caffe_rng_uniform(1, static_cast<float>(0), cumulative.back(), &val);
+
+  // Find the position within the sequence and add 1
+  return (std::lower_bound(cumulative.begin(), cumulative.end(), val)
+          - cumulative.begin());
+}
+
+template <typename T>
+bool is_border(const cv::Mat& edge, T color) {
+  cv::Mat im = edge.clone().reshape(0, 1);
+  bool res = true;
+  for (int i = 0; i < im.cols; ++i) {
+    res &= (color == im.at<T>(0, i));
+  }
+  return res;
+}
+
+template
+bool is_border(const cv::Mat& edge, uchar color);
+
+template <typename T>
+cv::Rect CropMask(const cv::Mat& src, T point, int padding) {
+  cv::Rect win(0, 0, src.cols, src.rows);
+
+  vector<cv::Rect> edges;
+  edges.push_back(cv::Rect(0, 0, src.cols, 1));
+  edges.push_back(cv::Rect(src.cols-2, 0, 1, src.rows));
+  edges.push_back(cv::Rect(0, src.rows-2, src.cols, 1));
+  edges.push_back(cv::Rect(0, 0, 1, src.rows));
+
+  cv::Mat edge;
+  int nborder = 0;
+  T color = src.at<T>(0, 0);
+  for (int i = 0; i < edges.size(); ++i) {
+    edge = src(edges[i]);
+    nborder += is_border(edge, color);
+  }
+
+  if (nborder < 4) {
+    return win;
+  }
+
+  bool next;
+  do {
+    edge = src(cv::Rect(win.x, win.height - 2, win.width, 1));
+    next = is_border(edge, color);
+    if (next) {
+      win.height--;
+    }
+  } while (next && (win.height > 0));
+
+  do {
+    edge = src(cv::Rect(win.width - 2, win.y, 1, win.height));
+    next = is_border(edge, color);
+    if (next) {
+      win.width--;
+    }
+  } while (next && (win.width > 0));
+
+  do {
+    edge = src(cv::Rect(win.x, win.y, win.width, 1));
+    next = is_border(edge, color);
+    if (next) {
+      win.y++;
+      win.height--;
+    }
+  } while (next && (win.y <= src.rows));
+
+  do {
+    edge = src(cv::Rect(win.x, win.y, 1, win.height));
+    next = is_border(edge, color);
+    if (next) {
+      win.x++;
+      win.width--;
+    }
+  } while (next && (win.x <= src.cols));
+
+  // add padding
+  if (win.x > padding) {
+    win.x -= padding;
+  }
+  if (win.y > padding) {
+    win.y -= padding;
+  }
+  if ((win.width + win.x + padding) < src.cols) {
+    win.width += padding;
+  }
+  if ((win.height + win.y + padding) < src.rows) {
+    win.height += padding;
+  }
+
+  return win;
+}
+
+template
+cv::Rect CropMask(const cv::Mat& src, uchar point, int padding);
+
+cv::Mat colorReduce(const cv::Mat& image, int div) {
+  cv::Mat out_img;
+  cv::Mat lookUpTable(1, 256, CV_8U);
+  uchar* p = lookUpTable.data;
+  const int div_2 = div / 2;
+  for ( int i = 0; i < 256; ++i ) {
+    p[i] = i / div * div + div_2;
+  }
+  cv::LUT(image, lookUpTable, out_img);
+  return out_img;
+}
+
+void fillEdgeImage(const cv::Mat& edgesIn, cv::Mat* filledEdgesOut) {
+  cv::Mat edgesNeg = edgesIn.clone();
+  cv::Scalar val(255, 255, 255);
+  cv::floodFill(edgesNeg, cv::Point(0, 0), val);
+  cv::floodFill(edgesNeg, cv::Point(edgesIn.cols - 1, edgesIn.rows - 1), val);
+  cv::floodFill(edgesNeg, cv::Point(0, edgesIn.rows - 1), val);
+  cv::floodFill(edgesNeg, cv::Point(edgesIn.cols - 1, 0), val);
+  cv::bitwise_not(edgesNeg, edgesNeg);
+  *filledEdgesOut = (edgesNeg | edgesIn);
+  return;
+}
+
+void CenterObjectAndFillBg(const cv::Mat& in_img, const bool fill_bg,
+                           cv::Mat* out_img) {
+  cv::Mat mask, crop_mask;
+  if (in_img.channels() > 1) {
+    cv::Mat in_img_gray;
+    cv::cvtColor(in_img, in_img_gray, CV_BGR2GRAY);
+    cv::threshold(in_img_gray, mask, 0, 255,
+                  CV_THRESH_BINARY_INV | CV_THRESH_OTSU);
+  } else {
+    cv::threshold(in_img, mask, 0, 255,
+                  CV_THRESH_BINARY_INV | CV_THRESH_OTSU);
+  }
+  cv::Rect crop_rect = CropMask(mask, mask.at<uchar>(0, 0), 2);
+
+  if (fill_bg) {
+    cv::Mat temp_img = in_img(crop_rect);
+    fillEdgeImage(mask, &mask);
+    crop_mask = mask(crop_rect).clone();
+    *out_img = cv::Mat::zeros(crop_rect.size(), in_img.type());
+    temp_img.copyTo(*out_img, crop_mask);
+  } else {
+    *out_img = in_img(crop_rect).clone();
+  }
+}
+
+cv::Mat AspectKeepingResizeAndPad(const cv::Mat& in_img,
+                                  const int new_width, const int new_height,
+                                  const int pad_type,  const cv::Scalar pad_val,
+                                  const int interp_mode) {
+  cv::Mat img_resized;
+  float orig_aspect = static_cast<float>(in_img.cols) / in_img.rows;
+  float new_aspect = static_cast<float>(new_width) / new_height;
+
+  if (orig_aspect > new_aspect) {
+    int height = floor(static_cast<float>(new_width) / orig_aspect);
+    cv::resize(in_img, img_resized, cv::Size(new_width, height), 0, 0,
+               interp_mode);
+    cv::Size resSize = img_resized.size();
+    int padding = floor((new_height - resSize.height) / 2.0);
+    cv::copyMakeBorder(img_resized, img_resized, padding,
+                       new_height - resSize.height - padding, 0, 0,
+                       pad_type, pad_val);
+  } else {
+    int width = floor(orig_aspect * new_height);
+    cv::resize(in_img, img_resized, cv::Size(width, new_height), 0, 0,
+               interp_mode);
+    cv::Size resSize = img_resized.size();
+    int padding = floor((new_width - resSize.width) / 2.0);
+    cv::copyMakeBorder(img_resized, img_resized, 0, 0, padding,
+                       new_width - resSize.width - padding,
+                       pad_type, pad_val);
+  }
+  return img_resized;
+}
+
+cv::Mat AspectKeepingResizeBySmall(const cv::Mat& in_img,
+                                   const int new_width,
+                                   const int new_height,
+                                   const int interp_mode) {
+  cv::Mat img_resized;
+  float orig_aspect = static_cast<float>(in_img.cols) / in_img.rows;
+  float new_aspect = static_cast<float> (new_width) / new_height;
+
+  if (orig_aspect < new_aspect) {
+    int height = floor(static_cast<float>(new_width) / orig_aspect);
+    cv::resize(in_img, img_resized, cv::Size(new_width, height), 0, 0,
+               interp_mode);
+  } else {
+    int width = floor(orig_aspect * new_height);
+    cv::resize(in_img, img_resized, cv::Size(width, new_height), 0, 0,
+               interp_mode);
+  }
+  return img_resized;
+}
+
+void constantNoise(const int n, const vector<uchar>& val, cv::Mat* image) {
+  const int cols = image->cols;
+  const int rows = image->rows;
+
+  if (image->channels() == 1) {
+    for (int k = 0; k < n; ++k) {
+      const int i = caffe_rng_rand() % cols;
+      const int j = caffe_rng_rand() % rows;
+      uchar* ptr = image->ptr<uchar>(j);
+      ptr[i]= val[0];
+    }
+  } else if (image->channels() == 3) {  // color image
+    for (int k = 0; k < n; ++k) {
+      const int i = caffe_rng_rand() % cols;
+      const int j = caffe_rng_rand() % rows;
+      cv::Vec3b* ptr = image->ptr<cv::Vec3b>(j);
+      (ptr[i])[0] = val[0];
+      (ptr[i])[1] = val[1];
+      (ptr[i])[2] = val[2];
+    }
+  }
+}
+
+void UpdateBBoxByResizePolicy(const ResizeParameter& param,
+                              const int old_width, const int old_height,
+                              NormalizedBBox* bbox) {
+  float new_height = param.height();
+  float new_width = param.width();
+  float orig_aspect = static_cast<float>(old_width) / old_height;
+  float new_aspect = new_width / new_height;
+
+  float x_min = bbox->xmin() * old_width;
+  float y_min = bbox->ymin() * old_height;
+  float x_max = bbox->xmax() * old_width;
+  float y_max = bbox->ymax() * old_height;
+  float padding;
+  switch (param.resize_mode()) {
+    case ResizeParameter_Resize_mode_WARP:
+      x_min = std::max(0.f, x_min * new_width / old_width);
+      x_max = std::min(new_width, x_max * new_width / old_width);
+      y_min = std::max(0.f, y_min * new_height / old_height);
+      y_max = std::min(new_height, y_max * new_height / old_height);
+      break;
+    case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+      if (orig_aspect > new_aspect) {
+        padding = (new_height - new_width / orig_aspect) / 2;
+        x_min = std::max(0.f, x_min * new_width / old_width);
+        x_max = std::min(new_width, x_max * new_width / old_width);
+        y_min = y_min * (new_height - 2 * padding) / old_height;
+        y_min = padding + std::max(0.f, y_min);
+        y_max = y_max * (new_height - 2 * padding) / old_height;
+        y_max = padding + std::min(new_height, y_max);
+      } else {
+        padding = new_width - orig_aspect * new_height / 2;
+        x_min = x_min * (new_width - 2 * padding) / old_width;
+        x_min = padding + std::max(0.f, x_min);
+        x_max = x_max * (new_width - 2*padding) / old_width;
+        x_max = padding + std::min(new_width, x_max);
+        y_min = std::max(0.f, y_min * new_height / old_height);
+        y_max = std::min(new_height, y_max * new_height / old_height);
+      }
+      break;
+    case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+      if (orig_aspect < new_aspect) {
+        new_height = new_width / orig_aspect;
+      } else {
+        new_width = orig_aspect * new_height;
+      }
+      x_min = std::max(0.f, x_min * new_width / old_width);
+      x_max = std::min(new_width, x_max * new_width / old_width);
+      y_min = std::max(0.f, y_min * new_height / old_height);
+      y_max = std::min(new_height, y_max * new_height / old_height);
+      break;
+    default:
+      LOG(FATAL) << "Unknown resize mode.";
+  }
+  bbox->set_xmin(x_min / new_width);
+  bbox->set_ymin(y_min / new_height);
+  bbox->set_xmax(x_max / new_width);
+  bbox->set_ymax(y_max / new_height);
+}
+
+cv::Mat ApplyResize(const cv::Mat& in_img, const ResizeParameter& param) {
+  cv::Mat out_img;
+
+  // Reading parameters
+  const int new_height = param.height();
+  const int new_width = param.width();
+
+  int pad_mode = cv::BORDER_CONSTANT;
+  switch (param.pad_mode()) {
+    case ResizeParameter_Pad_mode_CONSTANT:
+      break;
+    case ResizeParameter_Pad_mode_MIRRORED:
+      pad_mode = cv::BORDER_REFLECT101;
+      break;
+    case ResizeParameter_Pad_mode_REPEAT_NEAREST:
+      pad_mode = cv::BORDER_REPLICATE;
+      break;
+    default:
+      LOG(FATAL) << "Unknown pad mode.";
+  }
+
+  int interp_mode = cv::INTER_LINEAR;
+  int num_interp_mode = param.interp_mode_size();
+  if (num_interp_mode > 0) {
+    vector<float> probs(num_interp_mode, 1.f / num_interp_mode);
+    int prob_num = roll_weighted_die(probs);
+    switch (param.interp_mode(prob_num)) {
+      case ResizeParameter_Interp_mode_AREA:
+        interp_mode = cv::INTER_AREA;
+        break;
+      case ResizeParameter_Interp_mode_CUBIC:
+        interp_mode = cv::INTER_CUBIC;
+        break;
+      case ResizeParameter_Interp_mode_LINEAR:
+        interp_mode = cv::INTER_LINEAR;
+        break;
+      case ResizeParameter_Interp_mode_NEAREST:
+        interp_mode = cv::INTER_NEAREST;
+        break;
+      case ResizeParameter_Interp_mode_LANCZOS4:
+        interp_mode = cv::INTER_LANCZOS4;
+        break;
+      default:
+        LOG(FATAL) << "Unknown interp mode.";
+    }
+  }
+
+  cv::Scalar pad_val = cv::Scalar(0, 0, 0);
+  const int img_channels = in_img.channels();
+  if (param.pad_value_size() > 0) {
+    CHECK(param.pad_value_size() == 1 ||
+          param.pad_value_size() == img_channels) <<
+        "Specify either 1 pad_value or as many as channels: " << img_channels;
+    vector<float> pad_values;
+    for (int i = 0; i < param.pad_value_size(); ++i) {
+      pad_values.push_back(param.pad_value(i));
+    }
+    if (img_channels > 1 && param.pad_value_size() == 1) {
+      // Replicate the pad_value for simplicity
+      for (int c = 1; c < img_channels; ++c) {
+        pad_values.push_back(pad_values[0]);
+      }
+    }
+    pad_val = cv::Scalar(pad_values[0], pad_values[1], pad_values[2]);
+  }
+
+  switch (param.resize_mode()) {
+    case ResizeParameter_Resize_mode_WARP:
+      cv::resize(in_img, out_img, cv::Size(new_width, new_height), 0, 0,
+                 interp_mode);
+      break;
+    case ResizeParameter_Resize_mode_FIT_LARGE_SIZE_AND_PAD:
+      out_img = AspectKeepingResizeAndPad(in_img, new_width, new_height,
+                                          pad_mode, pad_val, interp_mode);
+      break;
+    case ResizeParameter_Resize_mode_FIT_SMALL_SIZE:
+      out_img = AspectKeepingResizeBySmall(in_img, new_width, new_height,
+                                           interp_mode);
+      break;
+    default:
+      LOG(INFO) << "Unknown resize mode.";
+  }
+  return  out_img;
+}
+
+cv::Mat ApplyNoise(const cv::Mat& in_img, const NoiseParameter& param) {
+  cv::Mat out_img;
+
+  if (param.decolorize()) {
+    cv::Mat grayscale_img;
+    cv::cvtColor(in_img, grayscale_img, CV_BGR2GRAY);
+    cv::cvtColor(grayscale_img, out_img,  CV_GRAY2BGR);
+  } else {
+    out_img = in_img;
+  }
+
+  if (param.gauss_blur()) {
+    cv::GaussianBlur(out_img, out_img, cv::Size(7, 7), 1.5);
+  }
+
+  if (param.hist_eq()) {
+    if (out_img.channels() > 1) {
+      cv::Mat ycrcb_image;
+      cv::cvtColor(out_img, ycrcb_image, CV_BGR2YCrCb);
+      // Extract the L channel
+      vector<cv::Mat> ycrcb_planes(3);
+      cv::split(ycrcb_image, ycrcb_planes);
+      // now we have the L image in ycrcb_planes[0]
+      cv::Mat dst;
+      cv::equalizeHist(ycrcb_planes[0], dst);
+      ycrcb_planes[0] = dst;
+      cv::merge(ycrcb_planes, ycrcb_image);
+      // convert back to RGB
+      cv::cvtColor(ycrcb_image, out_img, CV_YCrCb2BGR);
+    } else {
+      cv::Mat temp_img;
+      cv::equalizeHist(out_img, temp_img);
+      out_img = temp_img;
+    }
+  }
+
+  if (param.clahe()) {
+    cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+    clahe->setClipLimit(4);
+    if (out_img.channels() > 1) {
+      cv::Mat ycrcb_image;
+      cv::cvtColor(out_img, ycrcb_image, CV_BGR2YCrCb);
+      // Extract the L channel
+      vector<cv::Mat> ycrcb_planes(3);
+      cv::split(ycrcb_image, ycrcb_planes);
+      // now we have the L image in ycrcb_planes[0]
+      cv::Mat dst;
+      clahe->apply(ycrcb_planes[0], dst);
+      ycrcb_planes[0] = dst;
+      cv::merge(ycrcb_planes, ycrcb_image);
+      // convert back to RGB
+      cv::cvtColor(ycrcb_image, out_img, CV_YCrCb2BGR);
+    } else {
+      cv::Ptr<cv::CLAHE> clahe = cv::createCLAHE();
+      clahe->setClipLimit(4);
+      cv::Mat temp_img;
+      clahe->apply(out_img, temp_img);
+      out_img = temp_img;
+    }
+  }
+
+  if (param.jpeg() > 0) {
+    vector<uchar> buf;
+    vector<int> params;
+    params.push_back(CV_IMWRITE_JPEG_QUALITY);
+    params.push_back(param.jpeg());
+    cv::imencode(".jpg", out_img, buf, params);
+    out_img = cv::imdecode(buf, CV_LOAD_IMAGE_COLOR);
+  }
+
+  if (param.erode()) {
+    cv::Mat element = cv::getStructuringElement(
+        2, cv::Size(3, 3), cv::Point(1, 1));
+    cv::erode(out_img, out_img, element);
+  }
+
+  if (param.posterize()) {
+    cv::Mat tmp_img;
+    tmp_img = colorReduce(out_img);
+    out_img = tmp_img;
+  }
+
+  if (param.inverse()) {
+    cv::Mat tmp_img;
+    cv::bitwise_not(out_img, tmp_img);
+    out_img = tmp_img;
+  }
+
+  vector<uchar> noise_values;
+  if (param.saltpepper_param().value_size() > 0) {
+    CHECK(param.saltpepper_param().value_size() == 1
+          || param.saltpepper_param().value_size() == out_img.channels())
+        << "Specify either 1 pad_value or as many as channels: "
+        << out_img.channels();
+
+    for (int i = 0; i < param.saltpepper_param().value_size(); i++) {
+      noise_values.push_back(uchar(param.saltpepper_param().value(i)));
+    }
+    if (out_img.channels()  > 1
+        && param.saltpepper_param().value_size() == 1) {
+      // Replicate the pad_value for simplicity
+      for (int c = 1; c < out_img.channels(); ++c) {
+        noise_values.push_back(uchar(noise_values[0]));
+      }
+    }
+  }
+  if (param.saltpepper()) {
+    const int noise_pixels_num =
+        floor(param.saltpepper_param().fraction()
+              * out_img.cols * out_img.rows);
+    constantNoise(noise_pixels_num, noise_values, &out_img);
+  }
+
+  if (param.convert_to_hsv()) {
+    cv::Mat hsv_image;
+    cv::cvtColor(out_img, hsv_image, CV_BGR2HSV);
+    out_img = hsv_image;
+  }
+  if (param.convert_to_lab()) {
+    cv::Mat lab_image;
+    out_img.convertTo(lab_image, CV_32F);
+    lab_image *= 1.0 / 255;
+    cv::cvtColor(lab_image, out_img, CV_BGR2Lab);
+  }
+  return  out_img;
+}
+
+}  // namespace caffe
+
+#endif  // USE_OPENCV

--- a/src/caffe/util/io.cpp
+++ b/src/caffe/util/io.cpp
@@ -1,40 +1,10 @@
-/*
-All modification made by Intel Corporation: © 2016 Intel Corporation
-
-All contributions by the University of California:
-Copyright (c) 2014, 2015, The Regents of the University of California (Regents)
-All rights reserved.
-
-All other contributions:
-Copyright (c) 2014, 2015, the respective contributors
-All rights reserved.
-For the list of contributors go to https://github.com/BVLC/caffe/blob/master/CONTRIBUTORS.md
-
-
-Redistribution and use in source and binary forms, with or without
-modification, are permitted provided that the following conditions are met:
-
-    * Redistributions of source code must retain the above copyright notice,
-      this list of conditions and the following disclaimer.
-    * Redistributions in binary form must reproduce the above copyright
-      notice, this list of conditions and the following disclaimer in the
-      documentation and/or other materials provided with the distribution.
-    * Neither the name of Intel Corporation nor the names of its contributors
-      may be used to endorse or promote products derived from this software
-      without specific prior written permission.
-
-THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
-AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
-IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
-DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
-FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
-DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
-SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
-CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
-OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
-OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-*/
-
+#include <boost/algorithm/string/classification.hpp>
+#include <boost/algorithm/string/split.hpp>
+#include <boost/filesystem.hpp>
+#include <boost/foreach.hpp>
+#include <boost/property_tree/json_parser.hpp>
+#include <boost/property_tree/ptree.hpp>
+#include <boost/property_tree/xml_parser.hpp>
 #include <fcntl.h>
 #include <google/protobuf/io/coded_stream.h>
 #include <google/protobuf/io/zero_copy_stream_impl.h>
@@ -49,12 +19,11 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include <algorithm>
 #include <fstream>  // NOLINT(readability/streams)
+#include <map>
 #include <string>
 #include <vector>
 
 #include "caffe/common.hpp"
-#include "caffe/internode/configuration.hpp"
-#include "caffe/multinode/SendCallback.hpp"
 #include "caffe/proto/caffe.pb.h"
 #include "caffe/util/io.hpp"
 
@@ -62,6 +31,7 @@ const int kProtoReadBytesLimit = INT_MAX;  // Max size of 2 GB minus 1 byte.
 
 namespace caffe {
 
+using namespace boost::property_tree;  // NOLINT(build/namespaces)
 using google::protobuf::io::FileInputStream;
 using google::protobuf::io::FileOutputStream;
 using google::protobuf::io::ZeroCopyInputStream;
@@ -109,8 +79,9 @@ void WriteProtoToBinaryFile(const Message& proto, const char* filename) {
 }
 
 #ifdef USE_OPENCV
-cv::Mat ReadImageToCVMat(const string& filename,
-    const int height, const int width, const bool is_color) {
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim,
+    const bool is_color) {
   cv::Mat cv_img;
   int cv_read_flag = (is_color ? CV_LOAD_IMAGE_COLOR :
     CV_LOAD_IMAGE_GRAYSCALE);
@@ -119,12 +90,41 @@ cv::Mat ReadImageToCVMat(const string& filename,
     LOG(ERROR) << "Could not open or find file " << filename;
     return cv_img_origin;
   }
-  if (height > 0 && width > 0) {
+  if (min_dim > 0 || max_dim > 0) {
+    int num_rows = cv_img_origin.rows;
+    int num_cols = cv_img_origin.cols;
+    int min_num = std::min(num_rows, num_cols);
+    int max_num = std::max(num_rows, num_cols);
+    float scale_factor = 1;
+    if (min_dim > 0 && min_num < min_dim) {
+      scale_factor = static_cast<float>(min_dim) / min_num;
+    }
+    if (max_dim > 0 && static_cast<int>(scale_factor * max_num) > max_dim) {
+      // Make sure the maximum dimension is less than max_dim.
+      scale_factor = static_cast<float>(max_dim) / max_num;
+    }
+    if (scale_factor == 1) {
+      cv_img = cv_img_origin;
+    } else {
+      cv::resize(cv_img_origin, cv_img, cv::Size(0, 0),
+                 scale_factor, scale_factor);
+    }
+  } else if (height > 0 && width > 0) {
     cv::resize(cv_img_origin, cv_img, cv::Size(width, height));
   } else {
     cv_img = cv_img_origin;
   }
   return cv_img;
+}
+
+cv::Mat ReadImageToCVMat(const string& filename, const int height,
+    const int width, const int min_dim, const int max_dim) {
+  return ReadImageToCVMat(filename, height, width, min_dim, max_dim, true);
+}
+
+cv::Mat ReadImageToCVMat(const string& filename,
+    const int height, const int width, const bool is_color) {
+  return ReadImageToCVMat(filename, height, width, 0, 0, is_color);
 }
 
 cv::Mat ReadImageToCVMat(const string& filename,
@@ -144,7 +144,7 @@ cv::Mat ReadImageToCVMat(const string& filename) {
 // Do the file extension and encoding match?
 static bool matchExt(const std::string & fn,
                      std::string en) {
-  size_t p = fn.rfind('.');
+  size_t p = fn.rfind('.') + 1;
   std::string ext = p != fn.npos ? fn.substr(p) : fn;
   std::transform(ext.begin(), ext.end(), ext.begin(), ::tolower);
   std::transform(en.begin(), en.end(), en.begin(), ::tolower);
@@ -156,41 +156,78 @@ static bool matchExt(const std::string & fn,
 }
 
 bool ReadImageToDatum(const string& filename, const int label,
-    const int height, const int width, const bool is_color,
-    const std::string & encoding, Datum* datum) {
-  if (!encoding.size()) {
-    cv::Mat cv_img = ReadImageToCVMat(filename, height, width, is_color);
-    if (cv_img.data) {
-      CVMatToDatum(cv_img, datum);
+    const int height, const int width, const int min_dim, const int max_dim,
+    const bool is_color, const std::string & encoding, Datum* datum) {
+  cv::Mat cv_img = ReadImageToCVMat(filename, height, width, min_dim, max_dim,
+                                    is_color);
+  if (cv_img.data) {
+    if (encoding.size()) {
+      if ( (cv_img.channels() == 3) == is_color && !height && !width &&
+          !min_dim && !max_dim && matchExt(filename, encoding) )
+        return ReadFileToDatum(filename, label, datum);
+      EncodeCVMatToDatum(cv_img, encoding, datum);
       datum->set_label(label);
       return true;
-    } else {
-      return false;
     }
-  } else {
-    cv::Mat cv_img = cv::imread(filename, -1);
-    if (!cv_img.data) {
-      LOG(ERROR) << "Could not open or find file " << filename;
-      return false;
-    }
-    if ( (cv_img.channels() == 3) == is_color && !height && !width &&
-                                                matchExt(filename, encoding) )
-      return ReadFileToDatum(filename, label, datum);
-
-    if (height > 0 && width > 0)
-      cv::resize(cv_img, cv_img, cv::Size(width, height));
-    if ((cv_img.channels() == 3) != is_color)
-      cv::cvtColor(cv_img, cv_img, is_color ?
-                                       cv::COLOR_GRAY2BGR : cv::COLOR_BGR2GRAY);
-    std::vector<uchar> buf;
-    cv::imencode("."+encoding, cv_img, buf);
-    datum->set_data(std::string(reinterpret_cast<char*>(&buf[0]),
-                    buf.size()));
+    CVMatToDatum(cv_img, datum);
     datum->set_label(label);
-    datum->set_encoded(true);
     return true;
+  } else {
+    return false;
   }
 }
+
+void GetImageSize(const string& filename, int* height, int* width) {
+  cv::Mat cv_img = cv::imread(filename);
+  if (!cv_img.data) {
+    LOG(ERROR) << "Could not open or find file " << filename;
+    return;
+  }
+  *height = cv_img.rows;
+  *width = cv_img.cols;
+}
+
+bool ReadRichImageToAnnotatedDatum(const string& filename,
+    const string& labelfile, const int height, const int width,
+    const int min_dim, const int max_dim, const bool is_color,
+    const string& encoding, const AnnotatedDatum_AnnotationType type,
+    const string& labeltype, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  // Read image to datum.
+  bool status = ReadImageToDatum(filename, -1, height, width,
+                                 min_dim, max_dim, is_color, encoding,
+                                 anno_datum->mutable_datum());
+  if (status == false) {
+    return status;
+  }
+  anno_datum->clear_annotation_group();
+  if (!boost::filesystem::exists(labelfile)) {
+    return true;
+  }
+  switch (type) {
+    case AnnotatedDatum_AnnotationType_BBOX:
+      int ori_height, ori_width;
+      GetImageSize(filename, &ori_height, &ori_width);
+      if (labeltype == "xml") {
+        return ReadXMLToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                       name_to_label, anno_datum);
+      } else if (labeltype == "json") {
+        return ReadJSONToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                        name_to_label, anno_datum);
+      } else if (labeltype == "txt") {
+        return ReadTxtToAnnotatedDatum(labelfile, ori_height, ori_width,
+                                       anno_datum);
+      } else {
+        LOG(FATAL) << "Unknown label file type.";
+        return false;
+      }
+      break;
+    default:
+      LOG(FATAL) << "Unknown annotation type.";
+      return false;
+  }
+}
+
 #endif  // USE_OPENCV
 
 bool ReadFileToDatum(const string& filename, const int label,
@@ -211,6 +248,398 @@ bool ReadFileToDatum(const string& filename, const int label,
   } else {
     return false;
   }
+}
+
+// Parse VOC/ILSVRC detection annotation.
+bool ReadXMLToAnnotatedDatum(const string& labelfile, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  ptree pt;
+  read_xml(labelfile, pt);
+
+  // Parse annotation.
+  int width = 0, height = 0;
+  try {
+    height = pt.get<int>("annotation.size.height");
+    width = pt.get<int>("annotation.size.width");
+  } catch (const ptree_error &e) {
+    LOG(WARNING) << "When parsing " << labelfile << ": " << e.what();
+    height = img_height;
+    width = img_width;
+  }
+  LOG_IF(WARNING, height != img_height) << labelfile <<
+      " inconsistent image height.";
+  LOG_IF(WARNING, width != img_width) << labelfile <<
+      " inconsistent image width.";
+  CHECK(width != 0 && height != 0) << labelfile <<
+      " no valid image width/height.";
+  int instance_id = 0;
+  BOOST_FOREACH(ptree::value_type &v1, pt.get_child("annotation")) {
+    ptree pt1 = v1.second;
+    if (v1.first == "object") {
+      Annotation* anno = NULL;
+      bool difficult = false;
+      ptree object = v1.second;
+      BOOST_FOREACH(ptree::value_type &v2, object.get_child("")) {
+        ptree pt2 = v2.second;
+        if (v2.first == "name") {
+          string name = pt2.data();
+          if (name_to_label.find(name) == name_to_label.end()) {
+            LOG(FATAL) << "Unknown name: " << name;
+          }
+          int label = name_to_label.find(name)->second;
+          bool found_group = false;
+          for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+            AnnotationGroup* anno_group =
+                anno_datum->mutable_annotation_group(g);
+            if (label == anno_group->group_label()) {
+              if (anno_group->annotation_size() == 0) {
+                instance_id = 0;
+              } else {
+                instance_id = anno_group->annotation(
+                    anno_group->annotation_size() - 1).instance_id() + 1;
+              }
+              anno = anno_group->add_annotation();
+              found_group = true;
+            }
+          }
+          if (!found_group) {
+            // If there is no such annotation_group, create a new one.
+            AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+            anno_group->set_group_label(label);
+            anno = anno_group->add_annotation();
+            instance_id = 0;
+          }
+          anno->set_instance_id(instance_id++);
+        } else if (v2.first == "difficult") {
+          difficult = pt2.data() == "1";
+        } else if (v2.first == "bndbox") {
+          int xmin = pt2.get("xmin", 0);
+          int ymin = pt2.get("ymin", 0);
+          int xmax = pt2.get("xmax", 0);
+          int ymax = pt2.get("ymax", 0);
+          CHECK_NOTNULL(anno);
+          LOG_IF(WARNING, xmin > width) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymin > height) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmax > width) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymax > height) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmin < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymin < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmax < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, ymax < 0) << labelfile <<
+              " bounding box exceeds image boundary.";
+          LOG_IF(WARNING, xmin > xmax) << labelfile <<
+              " bounding box irregular.";
+          LOG_IF(WARNING, ymin > ymax) << labelfile <<
+              " bounding box irregular.";
+          // Store the normalized bounding box.
+          NormalizedBBox* bbox = anno->mutable_bbox();
+          bbox->set_xmin(static_cast<float>(xmin) / width);
+          bbox->set_ymin(static_cast<float>(ymin) / height);
+          bbox->set_xmax(static_cast<float>(xmax) / width);
+          bbox->set_ymax(static_cast<float>(ymax) / height);
+          bbox->set_difficult(difficult);
+        }
+      }
+    }
+  }
+  return true;
+}
+
+// Parse MSCOCO detection annotation.
+bool ReadJSONToAnnotatedDatum(const string& labelfile, const int img_height,
+    const int img_width, const std::map<string, int>& name_to_label,
+    AnnotatedDatum* anno_datum) {
+  ptree pt;
+  read_json(labelfile, pt);
+
+  // Get image info.
+  int width = 0, height = 0;
+  try {
+    height = pt.get<int>("image.height");
+    width = pt.get<int>("image.width");
+  } catch (const ptree_error &e) {
+    LOG(WARNING) << "When parsing " << labelfile << ": " << e.what();
+    height = img_height;
+    width = img_width;
+  }
+  LOG_IF(WARNING, height != img_height) << labelfile <<
+      " inconsistent image height.";
+  LOG_IF(WARNING, width != img_width) << labelfile <<
+      " inconsistent image width.";
+  CHECK(width != 0 && height != 0) << labelfile <<
+      " no valid image width/height.";
+
+  // Get annotation info.
+  int instance_id = 0;
+  BOOST_FOREACH(ptree::value_type& v1, pt.get_child("annotation")) {
+    Annotation* anno = NULL;
+    bool iscrowd = false;
+    ptree object = v1.second;
+    // Get category_id.
+    string name = object.get<string>("category_id");
+    if (name_to_label.find(name) == name_to_label.end()) {
+      LOG(FATAL) << "Unknown name: " << name;
+    }
+    int label = name_to_label.find(name)->second;
+    bool found_group = false;
+    for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+      AnnotationGroup* anno_group =
+          anno_datum->mutable_annotation_group(g);
+      if (label == anno_group->group_label()) {
+        if (anno_group->annotation_size() == 0) {
+          instance_id = 0;
+        } else {
+          instance_id = anno_group->annotation(
+              anno_group->annotation_size() - 1).instance_id() + 1;
+        }
+        anno = anno_group->add_annotation();
+        found_group = true;
+      }
+    }
+    if (!found_group) {
+      // If there is no such annotation_group, create a new one.
+      AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+      anno_group->set_group_label(label);
+      anno = anno_group->add_annotation();
+      instance_id = 0;
+    }
+    anno->set_instance_id(instance_id++);
+
+    // Get iscrowd.
+    iscrowd = object.get<int>("iscrowd", 0);
+
+    // Get bbox.
+    vector<float> bbox_items;
+    BOOST_FOREACH(ptree::value_type& v2, object.get_child("bbox")) {
+      bbox_items.push_back(v2.second.get_value<float>());
+    }
+    CHECK_EQ(bbox_items.size(), 4);
+    float xmin = bbox_items[0];
+    float ymin = bbox_items[1];
+    float xmax = bbox_items[0] + bbox_items[2];
+    float ymax = bbox_items[1] + bbox_items[3];
+    CHECK_NOTNULL(anno);
+    LOG_IF(WARNING, xmin > width) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin > height) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax > width) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax > height) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax < 0) << labelfile <<
+        " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin > xmax) << labelfile <<
+        " bounding box irregular.";
+    LOG_IF(WARNING, ymin > ymax) << labelfile <<
+        " bounding box irregular.";
+    // Store the normalized bounding box.
+    NormalizedBBox* bbox = anno->mutable_bbox();
+    bbox->set_xmin(xmin / width);
+    bbox->set_ymin(ymin / height);
+    bbox->set_xmax(xmax / width);
+    bbox->set_ymax(ymax / height);
+    bbox->set_difficult(iscrowd);
+  }
+  return true;
+}
+
+// Parse plain txt detection annotation: label_id, xmin, ymin, xmax, ymax.
+bool ReadTxtToAnnotatedDatum(const string& labelfile, const int height,
+    const int width, AnnotatedDatum* anno_datum) {
+  std::ifstream infile(labelfile.c_str());
+  if (!infile.good()) {
+    LOG(INFO) << "Cannot open " << labelfile;
+    return false;
+  }
+  int label;
+  float xmin, ymin, xmax, ymax;
+  while (infile >> label >> xmin >> ymin >> xmax >> ymax) {
+    Annotation* anno = NULL;
+    int instance_id = 0;
+    bool found_group = false;
+    for (int g = 0; g < anno_datum->annotation_group_size(); ++g) {
+      AnnotationGroup* anno_group = anno_datum->mutable_annotation_group(g);
+      if (label == anno_group->group_label()) {
+        if (anno_group->annotation_size() == 0) {
+          instance_id = 0;
+        } else {
+          instance_id = anno_group->annotation(
+              anno_group->annotation_size() - 1).instance_id() + 1;
+        }
+        anno = anno_group->add_annotation();
+        found_group = true;
+      }
+    }
+    if (!found_group) {
+      // If there is no such annotation_group, create a new one.
+      AnnotationGroup* anno_group = anno_datum->add_annotation_group();
+      anno_group->set_group_label(label);
+      anno = anno_group->add_annotation();
+      instance_id = 0;
+    }
+    anno->set_instance_id(instance_id++);
+    LOG_IF(WARNING, xmin > width) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin > height) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax > width) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax > height) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymin < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmax < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, ymax < 0) << labelfile <<
+      " bounding box exceeds image boundary.";
+    LOG_IF(WARNING, xmin > xmax) << labelfile <<
+      " bounding box irregular.";
+    LOG_IF(WARNING, ymin > ymax) << labelfile <<
+      " bounding box irregular.";
+    // Store the normalized bounding box.
+    NormalizedBBox* bbox = anno->mutable_bbox();
+    bbox->set_xmin(xmin / width);
+    bbox->set_ymin(ymin / height);
+    bbox->set_xmax(xmax / width);
+    bbox->set_ymax(ymax / height);
+    bbox->set_difficult(false);
+  }
+  return true;
+}
+
+bool ReadLabelFileToLabelMap(const string& filename, bool include_background,
+    const string& delimiter, LabelMap* map) {
+  // cleanup
+  map->Clear();
+
+  std::ifstream file(filename.c_str());
+  string line;
+  // Every line can have [1, 3] number of fields.
+  // The delimiter between fields can be one of " :;".
+  // The order of the fields are:
+  //  name [label] [display_name]
+  //  ...
+  int field_size = -1;
+  int label = 0;
+  LabelMapItem* map_item;
+  // Add background (none_of_the_above) class.
+  if (include_background) {
+    map_item = map->add_item();
+    map_item->set_name("none_of_the_above");
+    map_item->set_label(label++);
+    map_item->set_display_name("background");
+  }
+  while (std::getline(file, line)) {
+    vector<string> fields;
+    fields.clear();
+    boost::split(fields, line, boost::is_any_of(delimiter));
+    if (field_size == -1) {
+      field_size = fields.size();
+    } else {
+      CHECK_EQ(field_size, fields.size())
+          << "Inconsistent number of fields per line.";
+    }
+    map_item = map->add_item();
+    map_item->set_name(fields[0]);
+    switch (field_size) {
+      case 1:
+        map_item->set_label(label++);
+        map_item->set_display_name(fields[0]);
+        break;
+      case 2:
+        label = std::atoi(fields[1].c_str());
+        map_item->set_label(label);
+        map_item->set_display_name(fields[0]);
+        break;
+      case 3:
+        label = std::atoi(fields[1].c_str());
+        map_item->set_label(label);
+        map_item->set_display_name(fields[2]);
+        break;
+      default:
+        LOG(FATAL) << "The number of fields should be [1, 3].";
+        break;
+    }
+  }
+  return true;
+}
+
+bool MapNameToLabel(const LabelMap& map, const bool strict_check,
+    std::map<string, int>* name_to_label) {
+  // cleanup
+  name_to_label->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& name = map.item(i).name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!name_to_label->insert(std::make_pair(name, label)).second) {
+        LOG(FATAL) << "There are many duplicates of name: " << name;
+        return false;
+      }
+    } else {
+      (*name_to_label)[name] = label;
+    }
+  }
+  return true;
+}
+
+bool MapLabelToName(const LabelMap& map, const bool strict_check,
+    std::map<int, string>* label_to_name) {
+  // cleanup
+  label_to_name->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& name = map.item(i).name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!label_to_name->insert(std::make_pair(label, name)).second) {
+        LOG(FATAL) << "There are many duplicates of label: " << label;
+        return false;
+      }
+    } else {
+      (*label_to_name)[label] = name;
+    }
+  }
+  return true;
+}
+
+bool MapLabelToDisplayName(const LabelMap& map, const bool strict_check,
+    std::map<int, string>* label_to_display_name) {
+  // cleanup
+  label_to_display_name->clear();
+
+  for (int i = 0; i < map.item_size(); ++i) {
+    const string& display_name = map.item(i).display_name();
+    const int label = map.item(i).label();
+    if (strict_check) {
+      if (!label_to_display_name->insert(
+              std::make_pair(label, display_name)).second) {
+        LOG(FATAL) << "There are many duplicates of label: " << label;
+        return false;
+      }
+    } else {
+      (*label_to_display_name)[label] = display_name;
+    }
+  }
+  return true;
 }
 
 #ifdef USE_OPENCV
@@ -258,6 +687,18 @@ bool DecodeDatum(Datum* datum, bool is_color) {
   } else {
     return false;
   }
+}
+
+void EncodeCVMatToDatum(const cv::Mat& cv_img, const string& encoding,
+                        Datum* datum) {
+  std::vector<uchar> buf;
+  cv::imencode("."+encoding, cv_img, buf);
+  datum->set_data(std::string(reinterpret_cast<char*>(&buf[0]),
+                              buf.size()));
+  datum->set_channels(cv_img.channels());
+  datum->set_height(cv_img.rows);
+  datum->set_width(cv_img.cols);
+  datum->set_encoded(true);
 }
 
 void CVMatToDatum(const cv::Mat& cv_img, Datum* datum) {

--- a/src/caffe/util/sampler.cpp
+++ b/src/caffe/util/sampler.cpp
@@ -1,0 +1,163 @@
+#include <algorithm>
+#include <vector>
+
+#include "caffe/util/bbox_util.hpp"
+#include "caffe/util/sampler.hpp"
+
+namespace caffe {
+
+void GroupObjectBBoxes(const AnnotatedDatum& anno_datum,
+                       vector<NormalizedBBox>* object_bboxes) {
+  object_bboxes->clear();
+  for (int i = 0; i < anno_datum.annotation_group_size(); ++i) {
+    const AnnotationGroup& anno_group = anno_datum.annotation_group(i);
+    for (int j = 0; j < anno_group.annotation_size(); ++j) {
+      const Annotation& anno = anno_group.annotation(j);
+      object_bboxes->push_back(anno.bbox());
+    }
+  }
+}
+
+bool SatisfySampleConstraint(const NormalizedBBox& sampled_bbox,
+                             const vector<NormalizedBBox>& object_bboxes,
+                             const SampleConstraint& sample_constraint) {
+  bool has_jaccard_overlap = sample_constraint.has_min_jaccard_overlap() ||
+      sample_constraint.has_max_jaccard_overlap();
+  bool has_sample_coverage = sample_constraint.has_min_sample_coverage() ||
+      sample_constraint.has_max_sample_coverage();
+  bool has_object_coverage = sample_constraint.has_min_object_coverage() ||
+      sample_constraint.has_max_object_coverage();
+  bool satisfy = !has_jaccard_overlap && !has_sample_coverage &&
+      !has_object_coverage;
+  if (satisfy) {
+    // By default, the sampled_bbox is "positive" if no constraints are defined.
+    return true;
+  }
+  // Check constraints.
+  bool found = false;
+  for (int i = 0; i < object_bboxes.size(); ++i) {
+    const NormalizedBBox& object_bbox = object_bboxes[i];
+    // Test jaccard overlap.
+    if (has_jaccard_overlap) {
+      const float jaccard_overlap = JaccardOverlap(sampled_bbox, object_bbox);
+      if (sample_constraint.has_min_jaccard_overlap() &&
+          jaccard_overlap < sample_constraint.min_jaccard_overlap()) {
+        continue;
+      }
+      if (sample_constraint.has_max_jaccard_overlap() &&
+          jaccard_overlap > sample_constraint.max_jaccard_overlap()) {
+        continue;
+      }
+      found = true;
+    }
+    // Test sample coverage.
+    if (has_sample_coverage) {
+      const float sample_coverage = BBoxCoverage(sampled_bbox, object_bbox);
+      if (sample_constraint.has_min_sample_coverage() &&
+          sample_coverage < sample_constraint.min_sample_coverage()) {
+        continue;
+      }
+      if (sample_constraint.has_max_sample_coverage() &&
+          sample_coverage > sample_constraint.max_sample_coverage()) {
+        continue;
+      }
+      found = true;
+    }
+    // Test object coverage.
+    if (has_object_coverage) {
+      const float object_coverage = BBoxCoverage(object_bbox, sampled_bbox);
+      if (sample_constraint.has_min_object_coverage() &&
+          object_coverage < sample_constraint.min_object_coverage()) {
+        continue;
+      }
+      if (sample_constraint.has_max_object_coverage() &&
+          object_coverage > sample_constraint.max_object_coverage()) {
+        continue;
+      }
+      found = true;
+    }
+    if (found) {
+      return true;
+    }
+  }
+  return found;
+}
+
+void SampleBBox(const Sampler& sampler, NormalizedBBox* sampled_bbox) {
+  // Get random scale.
+  CHECK_GE(sampler.max_scale(), sampler.min_scale());
+  CHECK_GT(sampler.min_scale(), 0.);
+  CHECK_LE(sampler.max_scale(), 1.);
+  float scale;
+  caffe_rng_uniform(1, sampler.min_scale(), sampler.max_scale(), &scale);
+
+  // Get random aspect ratio.
+  CHECK_GE(sampler.max_aspect_ratio(), sampler.min_aspect_ratio());
+  CHECK_GT(sampler.min_aspect_ratio(), 0.);
+  CHECK_LT(sampler.max_aspect_ratio(), FLT_MAX);
+  float aspect_ratio;
+  float min_aspect_ratio = std::max<float>(sampler.min_aspect_ratio(),
+                                           std::pow(scale, 2.));
+  float max_aspect_ratio = std::min<float>(sampler.max_aspect_ratio(),
+                                           1 / std::pow(scale, 2.));
+  caffe_rng_uniform(1, min_aspect_ratio, max_aspect_ratio, &aspect_ratio);
+
+  // Figure out bbox dimension.
+  float bbox_width = scale * sqrt(aspect_ratio);
+  float bbox_height = scale / sqrt(aspect_ratio);
+
+  // Figure out top left coordinates.
+  float w_off, h_off;
+  caffe_rng_uniform(1, 0.f, 1 - bbox_width, &w_off);
+  caffe_rng_uniform(1, 0.f, 1 - bbox_height, &h_off);
+
+  sampled_bbox->set_xmin(w_off);
+  sampled_bbox->set_ymin(h_off);
+  sampled_bbox->set_xmax(w_off + bbox_width);
+  sampled_bbox->set_ymax(h_off + bbox_height);
+}
+
+void GenerateSamples(const NormalizedBBox& source_bbox,
+                     const vector<NormalizedBBox>& object_bboxes,
+                     const BatchSampler& batch_sampler,
+                     vector<NormalizedBBox>* sampled_bboxes) {
+  int found = 0;
+  for (int i = 0; i < batch_sampler.max_trials(); ++i) {
+    if (batch_sampler.has_max_sample() &&
+        found >= batch_sampler.max_sample()) {
+      break;
+    }
+    // Generate sampled_bbox in the normalized space [0, 1].
+    NormalizedBBox sampled_bbox;
+    SampleBBox(batch_sampler.sampler(), &sampled_bbox);
+    // Transform the sampled_bbox w.r.t. source_bbox.
+    LocateBBox(source_bbox, sampled_bbox, &sampled_bbox);
+    // Determine if the sampled bbox is positive or negative by the constraint.
+    if (SatisfySampleConstraint(sampled_bbox, object_bboxes,
+                                batch_sampler.sample_constraint())) {
+      ++found;
+      sampled_bboxes->push_back(sampled_bbox);
+    }
+  }
+}
+
+void GenerateBatchSamples(const AnnotatedDatum& anno_datum,
+                          const vector<BatchSampler>& batch_samplers,
+                          vector<NormalizedBBox>* sampled_bboxes) {
+  sampled_bboxes->clear();
+  vector<NormalizedBBox> object_bboxes;
+  GroupObjectBBoxes(anno_datum, &object_bboxes);
+  for (int i = 0; i < batch_samplers.size(); ++i) {
+    if (batch_samplers[i].use_original_image()) {
+      NormalizedBBox unit_bbox;
+      unit_bbox.set_xmin(0);
+      unit_bbox.set_ymin(0);
+      unit_bbox.set_xmax(1);
+      unit_bbox.set_ymax(1);
+      GenerateSamples(unit_bbox, object_bboxes, batch_samplers[i],
+                      sampled_bboxes);
+    }
+  }
+}
+
+}  // namespace caffe


### PR DESCRIPTION
Merged the code from https://github.com/weiliu89/caffe/tree/ssd
Currently, we only verified the code for SSD inference. 
Most files are new added from SSD code, thus without any conflict. However, to pass the compilation, some files from SSD is directly used to overwrite the intel/caffe implementation.

To verify the SSD example:
1) Prepare/Download the trained model, for example, download from http://www.cs.unc.edu/%7Ewliu/projects/SSD/models_VGGNet_VOC0712_SSD_300x300.tar.gz
and then extract the tar file:
tar zxvf models_VGGNet_VOC0712_SSD_300x300.tar.gz
2) Run the SSD example: ./build/examples/ssd/ssd_detect.bin ./examples/ssd/deploy.prototxt models/VGGNet/VOC0712/SSD_300x300/VGG_VOC0712_SSD_300x300_iter_60000.caffemodel ./examples/ssd/images.txt
Note: Please use the modified deploy.prototxt to get much better performance.