### PR TITLE
Add option for JPEG-encoded LMDB to create_imagenet.sh

### DIFF
--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -57,6 +57,17 @@ else
   RESIZE_WIDTH=0
 fi
 
+# Set ENCODE=true to encode the images as compressed JPEGs stored in the LMDB.
+# Leave as false for uncompressed (raw) images.
+ENCODE=false
+if $ENCODE; then
+  ENCODE_FLAG='--encoded=true'
+  ENCODE_TYPE_FLAG='--encode_type=jpg'
+else
+  ENCODE_FLAG='--encoded=false'
+  ENCODE_TYPE_FLAG=''
+fi
+
 if [ ! -d "$TRAIN_DATA_ROOT" ]; then
   echo "Error: TRAIN_DATA_ROOT is not a path to a directory: $TRAIN_DATA_ROOT"
   echo "Set the TRAIN_DATA_ROOT variable in create_imagenet.sh to the path" \
@@ -76,6 +87,8 @@ echo "Creating train lmdb..."
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
+    $ENCODE_FLAG \
+    $ENCODE_TYPE_FLAG \
     --shuffle \
     $TRAIN_DATA_ROOT \
     $DATA/train.txt \
@@ -86,6 +99,8 @@ echo "Creating val lmdb..."
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
+    $ENCODE_FLAG \
+    $ENCODE_TYPE_FLAG \
     --shuffle \
     $VAL_DATA_ROOT \
     $DATA/val.txt \


### PR DESCRIPTION
This adds an option to the `create_imagenet.sh` script to create a JPEG-encoded (compressed) LMDB.