### PR TITLE
Removed tabs for python 3 compatibility

### DIFF
--- a/examples/imagenet/create_imagenet.sh
+++ b/examples/imagenet/create_imagenet.sh
@@ -57,6 +57,17 @@ else
   RESIZE_WIDTH=0
 fi
 
+# Set ENCODE=true to encode the images as compressed JPEGs stored in the LMDB.
+# Leave as false for uncompressed (raw) images.
+ENCODE=false
+if $ENCODE; then
+  ENCODE_FLAG='--encoded=true'
+  ENCODE_TYPE_FLAG='--encode_type=jpg'
+else
+  ENCODE_FLAG='--encoded=false'
+  ENCODE_TYPE_FLAG=''
+fi
+
 if [ ! -d "$TRAIN_DATA_ROOT" ]; then
   echo "Error: TRAIN_DATA_ROOT is not a path to a directory: $TRAIN_DATA_ROOT"
   echo "Set the TRAIN_DATA_ROOT variable in create_imagenet.sh to the path" \
@@ -76,6 +87,8 @@ echo "Creating train lmdb..."
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
+    $ENCODE_FLAG \
+    $ENCODE_TYPE_FLAG \
     --shuffle \
     $TRAIN_DATA_ROOT \
     $DATA/train.txt \
@@ -86,6 +99,8 @@ echo "Creating val lmdb..."
 GLOG_logtostderr=1 $TOOLS/convert_imageset \
     --resize_height=$RESIZE_HEIGHT \
     --resize_width=$RESIZE_WIDTH \
+    $ENCODE_FLAG \
+    $ENCODE_TYPE_FLAG \
     --shuffle \
     $VAL_DATA_ROOT \
     $DATA/val.txt \

--- a/python/caffe/io.py
+++ b/python/caffe/io.py
@@ -298,11 +298,11 @@ class Transformer:
             if len(ms) != 3:
                 raise ValueError('Mean shape invalid')
             if ms != self.inputs[in_][1:]:
-		print(self.inputs[in_])
-		in_shape = self.inputs[in_][1:]
-		m_min, m_max = mean.min(), mean.max()
-		normal_mean = (mean - m_min) / (m_max - m_min)
-		mean = resize_image(normal_mean.transpose((1,2,0)),in_shape[1:]).transpose((2,0,1)) * (m_max - m_min) + m_min
+                print(self.inputs[in_])
+                in_shape = self.inputs[in_][1:]
+                m_min, m_max = mean.min(), mean.max()
+                normal_mean = (mean - m_min) / (m_max - m_min)
+                mean = resize_image(normal_mean.transpose((1,2,0)),in_shape[1:]).transpose((2,0,1)) * (m_max - m_min) + m_min
                 #aise ValueError('Mean shape incompatible with input shape.')
         self.mean[in_] = mean
 
@@ -363,7 +363,7 @@ def flip_image(im, scale=128, is_flow=False):
     """
     im = im[:, ::-1, :]  # flip for mirrors
     if is_flow:  #if using a flow input, should flip first channel which corresponds to x-flow
-      im[:,:,0] = scale-im[:,:,0]
+        im[:,:,0] = scale-im[:,:,0]
     return im
 
 def resize_image(im, new_dims, interp_order=1):


### PR DESCRIPTION
The file contained a mix of tabs and spaces, which is fine for python 2, but breaks on python 3
```
import: 'caffe'
Traceback (most recent call last):
  File "/workdir/conda-build/test-tmp_dir/run_test.py", line 26, in <module>
    import caffe
  File "/home/sat_bot/miniconda3/envs/_test/lib/python3.5/site-packages/caffe/__init__.py", line 37, in <module>
    from .pycaffe import Net, SGDSolver, NesterovSolver, AdaGradSolver, RMSPropSolver, AdaDeltaSolver, AdamSolver
  File "/home/sat_bot/miniconda3/envs/_test/lib/python3.5/site-packages/caffe/pycaffe.py", line 51, in <module>
    import caffe.io
  File "/home/sat_bot/miniconda3/envs/_test/lib/python3.5/site-packages/caffe/io.py", line 301
    print(self.inputs[in_])
                          ^
TabError: inconsistent use of tabs and spaces in indentation
```