### PR TITLE
Update NVCC Flags and Fix Dockerfiles+Build

### DIFF
--- a/cmake/Cuda.cmake
+++ b/cmake/Cuda.cmake
@@ -145,7 +145,7 @@ macro(caffe_cuda_compile objlist_variable)
   endforeach()
 
   if(UNIX OR APPLE)
-    list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC)
+    list(APPEND CUDA_NVCC_FLAGS -Xcompiler -fPIC -std=c++11)
   endif()
 
   if(APPLE)


### PR DESCRIPTION
This allows the GPU `dockerfile` and the build to compile. Otherwise, it will fail with NVCC errors because of a lack of C++11 support.

This has been tied to #86 and we can confirm that the build will now succeed with the changes.

Thank you to @ftian1 and most importantly @venvy-dev (Video++) for helping to support the Intel Caffe effort & community writ large.