### PR TITLE
fix bug in python/caffe/detector.py: unrounded index value will cause error.

### DIFF
--- a/python/caffe/detector.py
+++ b/python/caffe/detector.py
@@ -173,6 +173,7 @@ class Detector(caffe.Net):
         crop: cropped window.
         """
         # Crop window from the image.
+        window = np.round(window).astype(np.int)
         crop = im[window[0]:window[2], window[1]:window[3]]
 
         if self.context_pad:
@@ -207,10 +208,11 @@ class Detector(caffe.Net):
 
             # collect with context padding and place in input
             # with mean padding
+            box = np.round(box).astype(np.int)
             context_crop = im[box[0]:box[2], box[1]:box[3]]
             context_crop = caffe.io.resize_image(context_crop, (crop_h, crop_w))
             crop = np.ones(self.crop_dims, dtype=np.float32) * self.crop_mean
-            crop[pad_y:(pad_y + crop_h), pad_x:(pad_x + crop_w)] = context_crop
+            crop[int(pad_y):int(pad_y + crop_h), int(pad_x):int(pad_x + crop_w)] = context_crop 
 
         return crop
 


### PR DESCRIPTION
I have tried to detect regions from image using selective search, and I found that the input `window` is not rounded for indexing `im`, which is why it raised error when I was running `detect.py`. And problems regarding other fixes are likely.