### PR TITLE
Fix crash issue on running classification.bin and batch_classification.bin

### DIFF
--- a/examples/cpp_classification/batch_classification.cpp
+++ b/examples/cpp_classification/batch_classification.cpp
@@ -422,6 +422,10 @@ int main(int argc, char** argv) {
         cout<<"Use mean file: "<<FLAGS_mean_file<<endl;
     }
 
+#ifdef USE_MLSL
+    caffe::mn::init(&argc, &argv);
+#endif
+
     Classifier classifier(FLAGS_model, FLAGS_weights, FLAGS_mean_file,
             FLAGS_mean_value, FLAGS_label_file, FLAGS_engine, FLAGS_batch_size);
 

--- a/examples/cpp_classification/classification.cpp
+++ b/examples/cpp_classification/classification.cpp
@@ -275,6 +275,10 @@ int main(int argc, char** argv) {
 
   ::google::InitGoogleLogging(argv[0]);
 
+#ifdef USE_MLSL
+  caffe::mn::init(&argc, &argv);
+#endif
+
   string model_file   = argv[1];
   string trained_file = argv[2];
   string mean_file    = argv[3];


### PR DESCRIPTION
When using MLSL, caffe::mn::init() must be called.  If not, application will crash on getting node info.