### PR TITLE
Fix the '‘DeconvolutionLayer’ does not name a type' error.

### DIFF
--- a/src/caffe/layer_factory.cpp
+++ b/src/caffe/layer_factory.cpp
@@ -48,6 +48,7 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "caffe/layers/batch_norm_layer.hpp"
 #include "caffe/layers/concat_layer.hpp"
 #include "caffe/layers/conv_layer.hpp"
+#include "caffe/layers/deconv_layer.hpp"
 #include "caffe/layers/inner_product_layer.hpp"
 #include "caffe/layers/lrn_layer.hpp"
 #include "caffe/layers/pooling_layer.hpp"


### PR DESCRIPTION
Fix the '‘DeconvolutionLayer’ does not name a type' error.
include deconv_layer.hpp to layer_factory.cpp
Intel Caffe add new DeconvolutionLayer into layer_factory, but somehow the definition file has not been included. DeconvolutionLayer is defined in 'include/caffe/layers/deconv_layer.hpp'.
Detail:
'src/caffe/layer_factory.cpp:200:43: error: ‘DeconvolutionLayer’ does not name a type'
This error will occur while building Intel Caffe from the Source.
![2017-09-13 10 19 32](https://user-images.githubusercontent.com/16239566/30382439-b4f79826-98d1-11e7-8dd5-766ad9b3e1b2.png)
