### PR TITLE
fix #202

### DIFF
--- a/src/caffe/layers/mkldnn_inner_product_layer.cpp
+++ b/src/caffe/layers/mkldnn_inner_product_layer.cpp
@@ -358,10 +358,10 @@ void MKLDNNInnerProductLayer<Dtype>::InitInnerProductBwd(const vector<Blob<Dtype
  if (this->bias_term_)
     ipBwdWeights_desc.reset(new inner_product_backward_weights::desc(init_bottom_md, init_weights_md
                         , init_bias_md, init_top_md));
- else
+ else{
     ipBwdWeights_desc.reset(new inner_product_backward_weights::desc(init_bottom_md, init_weights_md
                         , init_top_md));
-
+ }
     ipBwdData_desc.reset(new inner_product_backward_data::desc(init_bottom_md, init_weights_md, init_top_md));
 
     // ---- Determining engine to use -----------------------


### PR DESCRIPTION
When I compiled caffe, this error occurred.
```
/home/pikachu/swcontest/intel_caffe/src/caffe/layers/mkldnn_inner_product_layer.cpp:361:2: error: this ‘else’ clause does not guard... [-Werror=misleading-indentation]
  else
  ^~~~
/home/pikachu/swcontest/intel_caffe/src/caffe/layers/mkldnn_inner_product_layer.cpp:365:5: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the ‘else’
     ipBwdData_desc.reset(new inner_product_backward_data::desc(init_bottom_md, init_weights_md, init_top_md));
     ^~~~~~~~~~~~~~
```
For more information, please refer to https://github.com/intel/caffe/issues/202
