### PR TITLE
fix some compile errors when set USE_OPENMP off

### DIFF
--- a/src/caffe/layers/mkldnn_convolution_layer.cpp
+++ b/src/caffe/layers/mkldnn_convolution_layer.cpp
@@ -262,14 +262,18 @@ void MKLDNNConvolutionLayer<Dtype>::InitConvolutionFwd(const vector<Blob<Dtype>*
       std::vector<float> scales(count);
       float scale;
       if(this->is_float_){
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i=0; i<count; i++){
           scale = this->scale_out_[0] / (this->scale_in_[0] * this->scale_params_[i]);
           scales[i] = scale;
         }
       } else {
         int output_shift;
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i=0; i<count; i++){
           output_shift = this->fl_layer_out_[0] - this->fl_layer_in_[0] - this->fl_params_[i];
           scale = pow(2. ,output_shift);
@@ -447,7 +451,9 @@ void MKLDNNConvolutionLayer<Dtype>::InitConvolutionFwd(const vector<Blob<Dtype>*
               count = oc;  //multi channel
           }
           std::vector<float> scale_weight(count);
+#ifdef _OPENMP
           #pragma omp parallel for if (count > 1)
+#endif
           for(int i=0; i<count; i++){
             scale_weight[i] = this->scale_params_[i];
           }
@@ -457,7 +463,9 @@ void MKLDNNConvolutionLayer<Dtype>::InitConvolutionFwd(const vector<Blob<Dtype>*
               count = oc;  //multi channel
           }
           std::vector<int> fl_weight(count);
+#ifdef _OPENMP
           #pragma omp parallel for if (count > 1)
+#endif
           for(int i=0; i<count; i++){
             fl_weight[i] = this->fl_params_[i];
           }
@@ -482,7 +490,9 @@ void MKLDNNConvolutionLayer<Dtype>::InitConvolutionFwd(const vector<Blob<Dtype>*
                   count = oc;  //multi channel
               }
               std::vector<float> scale_bias(count);
+#ifdef _OPENMP
               #pragma omp parallel for if (count > 1)
+#endif
               for(int i=0; i<count; i++){
                 scale_bias[i] = this->scale_in_[0] * this->scale_params_[i];
               }
@@ -492,7 +502,9 @@ void MKLDNNConvolutionLayer<Dtype>::InitConvolutionFwd(const vector<Blob<Dtype>*
                   count = oc;  //multi channel
               }
               std::vector<int> fl_bias(count);
+#ifdef _OPENMP
               #pragma omp parallel for if (count > 1)
+#endif
               for(int i=0; i<count; i++){
                 fl_bias[i] = this->fl_layer_in_[0] + this->fl_params_[i];
               }

--- a/src/caffe/layers/permute_layer.cpp
+++ b/src/caffe/layers/permute_layer.cpp
@@ -46,7 +46,9 @@ template <typename Dtype>
 void Permute(const int count, Dtype* bottom_data, const bool forward,
     const int* permute_order, const int* old_steps, const int* new_steps,
     const int num_axes, Dtype* top_data) {
+#ifdef _OPENMP
 #pragma omp parallel for
+#endif
     for (int i = 0; i < count; ++i) {
       int old_idx = 0;
       int idx = i;

--- a/src/caffe/mkldnn_memory.cpp
+++ b/src/caffe/mkldnn_memory.cpp
@@ -119,7 +119,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<f
     int count = scale.size();
     if ( *_usr_memory_pd != *_prv_memory_pd) {
         std::vector<float> scales_u2p(count);
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i=0; i < count; i++){
             scales_u2p[i] = scale[i];
         }
@@ -129,7 +131,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<f
                 new reorder::primitive_desc(*_usr_memory_pd, *_prv_memory_pd, attri));
 
         std::vector<float> scales_p2u(count);
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i=0; i < count; i++){
             scales_p2u[i] = (1. / scale[i]);
         }
@@ -147,7 +151,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<f
         }else{
             std::vector<float> scales_e2p(count);
             float shift_scale;
+#ifdef _OPENMP
             #pragma omp parallel for if (count > 1)
+#endif
             for(int i=0; i < count; i++){
                 shift_scale = scale[i] / scale_ext[i]; //fp32->int8 blob_prv_mkldnn_mem_descr->get_scale() will always be 0 ?
                 scales_e2p[i] = shift_scale;
@@ -180,7 +186,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<i
     float scale;
     if ( *_usr_memory_pd != *_prv_memory_pd) {
         std::vector<float> scales_u2p(count);
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i = 0; i < count; i++){
             scale = pow(2, fl[i]);
             scales_u2p[i] = scale;
@@ -191,7 +199,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<i
                 new reorder::primitive_desc(*_usr_memory_pd, *_prv_memory_pd, attri));
 
         std::vector<float> scales_p2u(count);
+#ifdef _OPENMP
         #pragma omp parallel for if (count > 1)
+#endif
         for(int i = 0; i < count; i++){
           scale = pow(2, -fl[i]);
           scales_p2u[i] = scale;
@@ -210,7 +220,9 @@ void MKLDNNMemoryDescriptorBase<Dtype>::create_reorder_descriptors(std::vector<i
         }else{
             std::vector<float> scales_e2p(count);
             int shift_fl;
+#ifdef _OPENMP
             #pragma omp parallel for if (count > 1)
+#endif
             for(int i = 0; i < count; i++){
                 shift_fl = fl[i] - fl_ext[i]; //fp32->int8 blob_prv_mkldnn_mem_descr->get_fl() will always be 0 ?
                 scale = pow(2, shift_fl);

--- a/src/caffe/multinode/mn_activation_layer.cpp
+++ b/src/caffe/multinode/mn_activation_layer.cpp
@@ -206,7 +206,9 @@ void MnActivationLayer<Dtype>::Backward_cpu(const vector<Blob<Dtype>*>& top,
 template <typename Dtype>
 void MnActivationLayer<Dtype>::Unpack(const Dtype *src, int N, int C, int HW, int numC, Dtype *dst) {
   int dstC = numC * C;
+#ifdef _OPENMP
 #pragma omp parallel for collapse (2)
+#endif
   for (int iN = 0; iN < N; iN++) {
     for (int iC = 0; iC < dstC; iC++) {
       int iSrc =  iC / C;
@@ -223,7 +225,9 @@ template <typename Dtype>
 void MnActivationLayer<Dtype>::Pack(const Dtype *src, Dtype *dst, int N, int C, int HW, int numC) {
   int srcC = numC * C;
   for (int iDst = 0; iDst < numC; iDst++) {
+#ifdef _OPENMP
 #pragma omp parallel for collapse (2)
+#endif
     for (int iN = 0; iN < N; iN++) {
       for (int iC = 0; iC < C; iC++) {
         int iSrcC = iDst * C + iC;


### PR DESCRIPTION
I add "#ifdef _OPENMP    #endif" where the code use openmp, I guess may be you forget these.