### PR TITLE
diable updating for batch norm parameters by setting local lr to zero

### DIFF
--- a/src/caffe/layers/batch_norm_layer.cpp
+++ b/src/caffe/layers/batch_norm_layer.cpp
@@ -72,6 +72,18 @@ void BatchNormLayer<Dtype>::LayerSetUp(const vector<Blob<Dtype>*>& bottom,
                 this->blobs_[i]->mutable_cpu_data());
     }
   }
+  // Mask statistics from optimization by setting local learning rates
+  // for mean, variance, and the bias correction to zero.
+  for (int i = 0; i < this->blobs_.size(); ++i) {
+    if (this->layer_param_.param_size() == i) {
+      ParamSpec* fixed_param_spec = this->layer_param_.add_param();
+      fixed_param_spec->set_lr_mult(0.f);
+    } else {
+      CHECK_EQ(this->layer_param_.param(i).lr_mult(), 0.f)
+          << "Cannot configure batch normalization statistics as layer "
+          << "parameters.";
+    }
+  }
 }
 
 template <typename Dtype>


### PR DESCRIPTION
My experiments proved that disable updating batch norm parameters is helpful when having very large mini batch size, for smaller mini batch size, it has almost the same accuracy as non-disabled one, and it gives stable loss decaying. However, I got this improvement from bvlc/caffe, it seems intel/caffe didn't integrate this improvement. 