### PR TITLE
fix bug: pycaffe net.params can't get param name info

### DIFF
--- a/include/caffe/net.hpp
+++ b/include/caffe/net.hpp
@@ -150,9 +150,9 @@ class Net {
    *        another Net.
    */
   void CopyTrainedLayersFrom(const NetParameter& param);
-  void CopyTrainedLayersFrom(const string trained_filename);
-  void CopyTrainedLayersFromBinaryProto(const string trained_filename);
-  void CopyTrainedLayersFromHDF5(const string trained_filename);
+  void CopyTrainedLayersFrom(const string& trained_filename);
+  void CopyTrainedLayersFromBinaryProto(const string& trained_filename);
+  void CopyTrainedLayersFromHDF5(const string& trained_filename);
   /// @brief Writes the net to a proto.
   void ToProto(NetParameter* param, bool write_diff = false) const;
   /// @brief Writes the net to an HDF5 file.

--- a/python/caffe/_caffe.cpp
+++ b/python/caffe/_caffe.cpp
@@ -372,7 +372,7 @@ BOOST_PYTHON_MODULE(_caffe) {
     .def("clear_param_diffs", static_cast<void (Net<Dtype>::*)(void)>(
     &Net<Dtype>::ClearParamDiffs))
     // The cast is to select a particular overload.
-    .def("copy_from", static_cast<void (Net<Dtype>::*)(const string)>(
+    .def("copy_from", static_cast<void (Net<Dtype>::*)(const string&)>(
         &Net<Dtype>::CopyTrainedLayersFrom))
     .def("share_with", &Net<Dtype>::ShareTrainedLayersWith)
     .add_property("_blob_loss_weights", bp::make_function(

--- a/src/caffe/net.cpp
+++ b/src/caffe/net.cpp
@@ -1448,7 +1448,7 @@ void Net<Dtype>::CopyTrainedLayersFrom(const NetParameter& param_inp) {
 }
 
 template <typename Dtype>
-void Net<Dtype>::CopyTrainedLayersFrom(const string trained_filename) {
+void Net<Dtype>::CopyTrainedLayersFrom(const string& trained_filename) {
   if (trained_filename.size() >= 3 &&
       trained_filename.compare(trained_filename.size() - 3, 3, ".h5") == 0) {
     CopyTrainedLayersFromHDF5(trained_filename);
@@ -1459,14 +1459,14 @@ void Net<Dtype>::CopyTrainedLayersFrom(const string trained_filename) {
 
 template <typename Dtype>
 void Net<Dtype>::CopyTrainedLayersFromBinaryProto(
-    const string trained_filename) {
+    const string& trained_filename) {
   NetParameter param;
   ReadNetParamsFromBinaryFileOrDie(trained_filename, &param);
   CopyTrainedLayersFrom(param);
 }
 
 template <typename Dtype>
-void Net<Dtype>::CopyTrainedLayersFromHDF5(const string trained_filename) {
+void Net<Dtype>::CopyTrainedLayersFromHDF5(const string& trained_filename) {
   hid_t file_hid = H5Fopen(trained_filename.c_str(), H5F_ACC_RDONLY,
                            H5P_DEFAULT);
   CHECK_GE(file_hid, 0) << "Couldn't open " << trained_filename;


### PR DESCRIPTION
refer the issue : https://github.com/intel/caffe/issues/307

pycaffe net api 'net.params' aways get null;

net = caffe.Net('resnet18.prototxt', 'resnet18.caffemodel', caffe.TEST)
for layer_name, param in **net.params.iteritems():**
print(layer_name)# **Result is NULL**

Intel Caffe net.params.iteritems() is Empty 